### PR TITLE
Astro migration M4: image optimization via Astro image service

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,9 @@ export default defineConfig({
   output: 'static',
   site: 'https://www.rhode-medizin.de',
   integrations: [sitemap()],
+  image: {
+    domains: ['images.ctfassets.net', 'videos.ctfassets.net'],
+  },
   vite: {
     resolve: {
       alias: {

--- a/docs/adrs/adr_05_image_strategy.md
+++ b/docs/adrs/adr_05_image_strategy.md
@@ -1,0 +1,62 @@
+# ADR 05: Image optimization strategy
+
+## Status
+
+Accepted
+
+## Context
+
+M3 delivered the Astro parity build using plain `<img>` tags with raw
+Contentful CDN URLs (no query parameters) and the Contentful asset's
+intrinsic `width`/`height`. The M4 milestone requires improving image
+delivery without changing content or layout, and without tying the
+feature to Contentful.
+
+The M4 design
+(`docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md`)
+chose Astro's built-in image service over hand-rolled Contentful CDN
+query-parameter transforms, so that switching the CMS or image source
+later means changing one `image.domains` entry and the loader's `src`
+data, not a Contentful-specific helper module.
+
+## Decision
+
+Use **Astro's built-in image service** (`astro:assets` `<Image />` and
+`<Picture />` components) for all Contentful images rendered by the
+Astro site.
+
+`astro.config.mjs` authorizes the Contentful asset hosts
+(`images.ctfassets.net` and `videos.ctfassets.net`) via `image.domains`
+so Astro downloads each remote asset once at build time, transforms it
+into the requested formats and widths, and emits optimized binaries
+under `/_astro/<hash>.<ext>`.
+
+Component choice is mixed per-context:
+
+- `HeroBlock.astro` (LCP image) uses `<Picture />` with
+  `formats={['avif', 'webp']}`, `fetchpriority="high"`, and
+  `loading="eager"` for AVIF/WebP format negotiation.
+- `EmployeeTile.astro` and `ProductGroup.astro` (below-the-fold images)
+  use `<Image />` with `loading="lazy"` for single-format WebP output.
+
+The Contentful loader's `ContentfulImage` shape is unchanged; its
+`src`, `width`, `height`, `title`, and `description` fields are passed
+directly to the Astro image components.
+
+No Contentful-specific image transform helper exists in the repo.
+
+## Consequences
+
+- Astro downloads and transforms authorized remote Contentful assets at
+  build time, increasing build time and `dist/` size. Astro's content
+  cache mitigates repeat builds.
+- The repo has no Contentful-specific image helper. Changing the image
+  source later means updating `image.domains` and the loader's `src`
+  data, not a transform module.
+- `<Picture />` emits a `<picture>` wrapper that the comparison scripts
+  collapse to its `<img>` child during content parity checks.
+- `/_astro/<hash>.<ext>` asset paths are normalized by the comparison
+  scripts so build-to-build hash variations do not break parity.
+- Build requires network access to `images.ctfassets.net`. The
+  Contentful loader already requires this for entry data, so no new
+  network dependency is introduced.

--- a/docs/superpowers/plans/2026-07-21-m4-astro-image-optimization.md
+++ b/docs/superpowers/plans/2026-07-21-m4-astro-image-optimization.md
@@ -1,0 +1,1201 @@
+# Astro Migration M4 Astro Image Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace plain `<img>` Contentful-URL rendering from M3 with Astro's built-in image service (`astro:assets`), without tying image optimization to Contentful and without changing content or layout.
+
+**Architecture:** Authorize the Contentful asset hosts in `astro.config.mjs` so Astro's image service can download and transform remote assets at build time. Replace the M3 plain `<img>` tags in `HeroBlock.astro` (LCP, `<Picture />` with AVIF/WebP), `EmployeeTile.astro`, and `ProductGroup.astro` (below-the-fold, `<Image />`) with Astro image components. Extend the comparison scripts to collapse `<picture>` wrappers and normalize Astro's `/_astro/<hash>.<ext>` output so content parity against the M3 baseline still passes.
+
+**Tech Stack:** Astro 7, `astro:assets` `<Image />` and `<Picture />` components, Cheerio-based comparison scripts.
+
+## Global Constraints
+
+- Consumes design: `docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md`.
+- Consumes master spec: `docs/superpowers/specs/2026-07-04-astro-migration-design.md`.
+- Depends on completed M3 parity build (commit `ac71660` "Remove Gatsby after Astro parity").
+- Do not combine image optimization with M2 or M3.
+- Images must retain appropriate `width`, `height`, `alt`, and lazy/eager loading behavior.
+- The homepage must not regress visually compared with the M3 plain-image baseline.
+- No cookies, service worker, or client-side storage may be introduced.
+- The Contentful loader's `ContentfulImage` shape (`{ src, width, height, title?, description? }`) is unchanged.
+- `src/lib/contentful-images.ts` must not exist at the end of M4 (it does not exist at the M3 baseline either — do not reintroduce it).
+- Run `pnpm build`, `pnpm compare:pages`, and `npm run lint` before considering work done.
+- Review for ADR need before completion and state whether ADRs were added or why none were needed.
+- Prettier config: no semicolons, single quotes, ES5 trailing commas, 2-space indent, LF.
+- No comments in code unless explicitly requested.
+
+---
+
+## File Structure
+
+- Reset: branch `astro-migration-v2-m4` to M3 baseline `ac71660`.
+- Modify: `astro.config.mjs` — add `image.domains` authorization.
+- Modify: `src/components/HeroBlock.astro` — replace `<img>` with `<Picture />`.
+- Modify: `src/components/EmployeeTile.astro` — replace `<img>` with `<Image />`.
+- Modify: `src/components/ProductGroup.astro` — replace `<img>` with `<Image />`.
+- Modify: `scripts/compare-pages.mjs` — add `collapsePictureElements()` and `/_astro/<hash>` normalization.
+- Modify: `scripts/compare-legal-pages.mjs` — add `collapsePictureElements()` and `/_astro/<hash>` normalization.
+- Create: `docs/adrs/adr_05_image_strategy.md` — record Astro image service decision.
+- Modify: `docs/superpowers/specs/2026-07-04-astro-migration-design.md` — update M4 decision point, Final stack Images line, and deliberate behavior changes.
+
+---
+
+### Task 1: Reset Branch To M3 Baseline
+
+**Files:**
+- None (git history operation only).
+
+**Interfaces:**
+- Consumes: M3 baseline commit `ac71660` "Remove Gatsby after Astro parity".
+- Produces: a clean `astro-migration-v2-m4` branch at `ac71660` with the two Contentful-CDN M4 commits (`5cf10e3`, `0ea8cfa`) removed from history.
+
+- [ ] **Step 1: Confirm current branch and commits to be removed**
+
+Run:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git log --oneline ac71660..HEAD
+```
+
+Expected: current branch is `astro-migration-v2-m4`; log shows exactly two commits: `0ea8cfa Optimize Astro image delivery` and `5cf10e3 Choose Contentful CDN image strategy`.
+
+- [ ] **Step 2: Confirm working tree is clean (ignoring untracked)**
+
+Run:
+
+```bash
+git status --porcelain
+```
+
+Expected: only untracked entries (`.idea/` and the new design doc `docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md`). No staged or modified tracked files.
+
+- [ ] **Step 3: Reset branch hard to M3 baseline**
+
+Run:
+
+```bash
+git reset --hard ac71660
+```
+
+Expected: HEAD now at `ac71660 Remove Gatsby after Astro parity`. The two Contentful M4 commits are gone from the branch.
+
+- [ ] **Step 4: Verify M3 baseline state**
+
+Run:
+
+```bash
+git log --oneline -3
+git status --porcelain
+```
+
+Expected: top commit is `ac71660 Remove Gatsby after Astro parity`; working tree shows only the untracked design doc (`.idea/` is gitignored or untracked).
+
+- [ ] **Step 5: Verify no Contentful image helper exists at baseline**
+
+Run:
+
+```bash
+ls src/lib/ 2>/dev/null || echo "src/lib does not exist (expected at M3 baseline)"
+ls docs/adrs/adr_05_image_strategy.md 2>/dev/null || echo "adr_05 does not exist (expected at M3 baseline)"
+```
+
+Expected: both prints report non-existence.
+
+- [ ] **Step 6: Preserve the design doc across the reset**
+
+The design doc at `docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md` is untracked, so `git reset --hard` does not remove it. Confirm it still exists:
+
+Run:
+
+```bash
+ls docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md
+```
+
+Expected: the file path prints (no "No such file" error).
+
+- [ ] **Step 7: Build the M3 baseline to confirm a clean starting point**
+
+Run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+```
+
+Expected: `pnpm build` succeeds (Astro check + build). This confirms the M3 baseline is healthy before any M4 change. If this fails, stop and fix the baseline before proceeding.
+
+- [ ] **Step 8: Commit the design doc**
+
+The design doc is the contract for the rest of M4. Commit it now so subsequent tasks have a stable reference.
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md
+git commit -m "Add M4 Astro image optimization design"
+```
+
+Expected: commit contains only the design doc.
+
+---
+
+### Task 2: Authorize Contentful Remote Images
+
+**Files:**
+- Modify: `astro.config.mjs`
+
+**Interfaces:**
+- Consumes: `ContentfulImage.src` absolute HTTPS URLs on `images.ctfassets.net` (and legacy `videos.ctfassets.net`) from the Contentful loader.
+- Produces: an Astro config that permits the image service to download and transform Contentful assets at build time. Later tasks' `<Image />` / `<Picture />` components rely on this authorization to optimize remote images.
+
+- [ ] **Step 1: Read the current astro.config.mjs**
+
+Run:
+
+```bash
+cat astro.config.mjs
+```
+
+Expected output (exactly):
+
+```js
+import { defineConfig } from 'astro/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  output: 'static',
+  vite: {
+    resolve: {
+      alias: {
+        '@content-loaders': fileURLToPath(
+          new URL('./src/content/loaders', import.meta.url),
+        ),
+      },
+    },
+  },
+})
+```
+
+- [ ] **Step 2: Add image.domains authorization**
+
+Edit `astro.config.mjs` to add an `image` key with `domains` listing the Contentful asset hosts. The full file content after the edit:
+
+```js
+import { defineConfig } from 'astro/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  output: 'static',
+  image: {
+    domains: ['images.ctfassets.net', 'videos.ctfassets.net'],
+  },
+  vite: {
+    resolve: {
+      alias: {
+        '@content-loaders': fileURLToPath(
+          new URL('./src/content/loaders', import.meta.url),
+        ),
+      },
+    },
+  },
+})
+```
+
+- [ ] **Step 3: Verify the build still succeeds with the new config**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: `pnpm build` succeeds. No image transformation happens yet (components still use plain `<img>`), but the config must be accepted by Astro.
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS (no prettier formatting errors).
+
+- [ ] **Step 5: Commit the config change**
+
+Run:
+
+```bash
+git status --short
+git diff -- astro.config.mjs
+git add astro.config.mjs
+git commit -m "Authorize Contentful images for Astro image service"
+```
+
+Expected: commit contains only `astro.config.mjs`.
+
+---
+
+### Task 3: Optimize Hero Image With Picture Component
+
+**Files:**
+- Modify: `src/components/HeroBlock.astro`
+
+**Interfaces:**
+- Consumes: `image?: ContentfulImage` prop (`{ src, width, height, title?, description? }`) from `ModuleRenderer.astro`.
+- Produces: an optimized hero `<picture>` with AVIF and WebP `<source>` entries and a fallback `<img>`, eager-loaded with `fetchpriority="high"`. The hero is the LCP element.
+
+- [ ] **Step 1: Read the current HeroBlock.astro**
+
+Run:
+
+```bash
+cat src/components/HeroBlock.astro
+```
+
+Expected: the M3 baseline version (plain `<img>` with `image.src`, `image.width`, `image.height`, `alt`, `fetchpriority="high"`). The frontmatter imports `MainGrid`, `ContentBox`, and `CallToActionButton`; computes `const alt = image?.description || image?.title || ''`.
+
+- [ ] **Step 2: Replace the frontmatter to import Picture from astro:assets**
+
+Edit `src/components/HeroBlock.astro`. Replace the import block and `alt` computation. The new frontmatter (everything between the `---` fences):
+
+```astro
+---
+// Native Astro port of src/components/heroBlock.jsx.
+// The hero area is a MainGrid variant with an absolutely positioned
+// background image, a content overlay (headline + subheadline), and a
+// call-to-action button. The hero image is the LCP element: it is eager
+// loaded with fetchpriority="high" and width/height attributes.
+import { Picture } from 'astro:assets'
+import MainGrid from './MainGrid.astro'
+import ContentBox from './ContentBox.astro'
+import CallToActionButton from './CallToActionButton.astro'
+
+interface Image {
+  src: string
+  width: number
+  height: number
+  title?: string
+  description?: string
+}
+
+interface Props {
+  mainHeadline: string
+  subHeadline?: string
+  callToAction?: string
+  image?: Image
+}
+
+const { mainHeadline, subHeadline, callToAction, image } = Astro.props
+const alt = image?.description || image?.title || ''
+---
+```
+
+- [ ] **Step 3: Replace the img with a Picture component**
+
+In the same file, replace the `<img class="hero-image" ... />` JSX block with a `<Picture />` component. The hero image fills the full viewport width as a background-style cover image, so `sizes="100vw"` and `layout="full-width"` let Astro generate a responsive srcset covering common viewport widths. The new markup block (replacing the old `{image && (<img .../>)}` block):
+
+```astro
+  {
+    image && (
+      <Picture
+        class="hero-image"
+        src={image.src}
+        width={image.width}
+        height={image.height}
+        alt={alt}
+        formats={['avif', 'webp']}
+        sizes="100vw"
+        layout="full-width"
+        loading="eager"
+        fetchpriority="high"
+      />
+    )
+  }
+```
+
+Leave the rest of the component (the `.hero-content` block and the entire `<style>` section) unchanged. The existing scoped `.hero-image` rule (`width: 100%; height: 100%; object-fit: cover; object-position: 50% 50%`) continues to drive the layout box; Astro's responsive `:where()` styles have specificity 0 and are overridden by the scoped rule.
+
+- [ ] **Step 4: Verify the build succeeds**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: `pnpm build` succeeds. Astro downloads the hero asset from `images.ctfassets.net`, transforms it into AVIF and WebP variants, and emits them under `/_astro/`. The build may be slower than M3 because of the remote download and transform.
+
+If the build fails with an unauthorized-domains error, confirm Task 2's `astro.config.mjs` change is present (`git diff astro.config.mjs`).
+
+- [ ] **Step 5: Inspect the built hero markup**
+
+Run:
+
+```bash
+grep -A 12 'class="hero-image"' dist/index.html
+```
+
+Expected: a `<picture>` element containing two `<source>` entries (`type="image/avif"`, `type="image/webp"`) with `srcset` attributes pointing at `/_astro/<hash>.avif` and `/_astro/<hash>.webp`, followed by an `<img class="hero-image" ... fetchpriority="high">` fallback whose `src` points at `/_astro/<hash>.<ext>`.
+
+- [ ] **Step 6: Run lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the hero optimization**
+
+Run:
+
+```bash
+git status --short
+git diff -- src/components/HeroBlock.astro
+git add src/components/HeroBlock.astro
+git commit -m "Optimize hero image with Astro Picture"
+```
+
+Expected: commit contains only `src/components/HeroBlock.astro`.
+
+---
+
+### Task 4: Optimize Below-The-Fold Images With Image Component
+
+**Files:**
+- Modify: `src/components/EmployeeTile.astro`
+- Modify: `src/components/ProductGroup.astro`
+
+**Interfaces:**
+- Consumes: `photo?: ContentfulImage` prop on each component.
+- Produces: optimized single-format WebP `<img>` output (via `<Image />`) with `loading="lazy"` for below-the-fold employee and product images.
+
+- [ ] **Step 1: Read the current EmployeeTile.astro**
+
+Run:
+
+```bash
+cat src/components/EmployeeTile.astro
+```
+
+Expected: the M3 baseline version (plain `<img class="photo" src={photo.src} width={300} height={182} alt={alt} loading="lazy" />`).
+
+- [ ] **Step 2: Replace EmployeeTile img with Image component**
+
+Edit `src/components/EmployeeTile.astro`. Add the `Image` import to the frontmatter and replace the `<img>` block. The employee photo renders at a fixed 300x182 box with `object-fit: cover`; pass the intrinsic `photo.width`/`photo.height` so Astro preserves the source aspect ratio, and let the existing scoped CSS crop to the tile. The full file content after the edit:
+
+```astro
+---
+// Native Astro port of src/components/employeeTile.jsx.
+// Renders a Mitarbeiter tile: a fixed 300x182 photo with a caption
+// overlay (name + department). The original used gatsby-image fixed
+// (300x182); the Astro port uses an optimized <Image> with
+// object-fit: cover to preserve the layout box.
+import { Image } from 'astro:assets'
+
+interface Image {
+  src: string
+  width: number
+  height: number
+  title?: string
+  description?: string
+}
+
+interface Props {
+  name: string
+  department?: string
+  photo?: Image
+}
+
+const { name, department, photo } = Astro.props
+const alt = photo?.description || photo?.title || ''
+---
+
+<div class="employee-tile">
+  {
+    photo && (
+      <Image
+        class="photo"
+        src={photo.src}
+        width={photo.width}
+        height={photo.height}
+        alt={alt}
+        loading="lazy"
+      />
+    )
+  }
+  <div class="caption">
+    {name}
+    <br />
+    {department}
+  </div>
+</div>
+
+<style>
+  .employee-tile {
+    min-width: 141px;
+    height: 182px;
+    border-radius: 3px;
+    overflow: hidden;
+    box-shadow: 3px 3px 5px 0px rgba(0, 0, 0, 0.5);
+    position: relative;
+  }
+
+  .photo {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: 50% 50%;
+  }
+
+  .caption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--color-overlay);
+    border: 1px solid white;
+    font-family: var(--font-bold);
+    font-size: 14px;
+    line-height: 1.235714286;
+    padding: 5px 10px;
+  }
+</style>
+```
+
+- [ ] **Step 3: Read the current ProductGroup.astro**
+
+Run:
+
+```bash
+cat src/components/ProductGroup.astro
+```
+
+Expected: the M3 baseline version (plain `<img class="product-image" src={photo.src} width={photo.width} height={photo.height} alt={alt} loading="lazy" />`).
+
+- [ ] **Step 4: Replace ProductGroup img with Image component**
+
+Edit `src/components/ProductGroup.astro`. Add the `Image` import and replace the `<img>` block. The product image is full-width on mobile and ~38vw on desktop; pass intrinsic dimensions and `sizes` so Astro generates an appropriate responsive srcset. The full file content after the edit:
+
+```astro
+---
+// Native Astro port of src/components/productGroup.jsx.
+// Renders a Produktgruppe tile: a two-column grid (image | text) on
+// large screens with header, description, and examples list. The
+// original used gatsby-image fluid; the Astro port uses an optimized
+// <Image> with object-fit: cover and the Contentful image dimensions.
+import { Image } from 'astro:assets'
+import ContentBox from './ContentBox.astro'
+
+interface Image {
+  src: string
+  width: number
+  height: number
+  title?: string
+  description?: string
+}
+
+interface Props {
+  name: string
+  description?: string
+  examples?: string[]
+  photo?: Image
+}
+
+const { name, description, examples = [], photo } = Astro.props
+const alt = photo?.description || photo?.title || ''
+---
+
+<section class="product-group">
+  {
+    photo && (
+      <Image
+        class="product-image"
+        src={photo.src}
+        width={photo.width}
+        height={photo.height}
+        alt={alt}
+        sizes="(min-width: 900px) 38vw, 100vw"
+        loading="lazy"
+      />
+    )
+  }
+  <ContentBox class="product-text">
+    <header class="product-header">
+      <h3>{name}</h3>
+    </header>
+    {description && <p class="product-description">{description}</p>}
+    {
+      examples.length > 0 && (
+        <ul class="product-examples">
+          {examples.map((example) => (
+            <li>{example}</li>
+          ))}
+        </ul>
+      )
+    }
+  </ContentBox>
+</section>
+
+<style>
+  .product-group {
+    background-color: var(--color-light-yellow);
+    border-radius: 3px;
+    overflow: hidden;
+    box-shadow: 6px 6px 5px 0px rgba(0, 0, 0, 0.5);
+  }
+
+  .product-image {
+    max-width: 100%;
+    height: 260px;
+    object-fit: cover;
+    object-position: 50% 50%;
+  }
+
+  @media (min-width: 900px) {
+    .product-group {
+      display: grid;
+      grid-template-columns: 1fr 1.618fr;
+      grid-template-rows: min-content 1fr;
+    }
+
+    @supports (display: grid) {
+      .product-group {
+        max-width: none;
+      }
+
+      .product-group :global(h3) {
+        margin-top: 0;
+      }
+    }
+
+    .product-image {
+      grid-row: span 2;
+    }
+  }
+
+  @media (min-width: 550px) {
+    .product-text {
+      padding: var(--base-line-height);
+    }
+
+    @supports (display: grid) {
+      .product-text {
+        display: grid;
+        grid-column-gap: var(--base-line-height);
+        grid-template-columns: 1.618fr 1fr;
+      }
+
+      .product-text :global(p),
+      .product-text :global(ol),
+      .product-text :global(ul) {
+        margin: 0;
+      }
+    }
+  }
+
+  .product-header {
+    grid-column: span 2;
+  }
+
+  .product-group :global(h3) {
+    color: var(--color-company-blue);
+    font-size: var(--font-size-l-small);
+    line-height: var(--line-height-l-small);
+  }
+
+  @media (min-width: 800px) {
+    .product-group :global(h3) {
+      font-size: var(--font-size-l-large);
+      line-height: var(--line-height-l-large);
+    }
+  }
+
+  .product-description {
+    font-size: var(--font-size-m-small);
+    line-height: var(--line-height-m-small);
+  }
+
+  @media (min-width: 800px) {
+    .product-description {
+      font-size: var(--font-size-m-large);
+      line-height: var(--line-height-m-large);
+    }
+  }
+
+  .product-examples > li {
+    font-size: var(--font-size-s-small);
+    line-height: var(--line-height-s-small);
+  }
+
+  @media (min-width: 800px) {
+    .product-examples > li {
+      font-size: var(--font-size-s-large);
+      line-height: var(--line-height-s-large);
+    }
+  }
+</style>
+```
+
+- [ ] **Step 5: Verify the build succeeds**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: `pnpm build` succeeds. Astro transforms employee and product images to WebP under `/_astro/`.
+
+- [ ] **Step 6: Inspect the built markup**
+
+Run:
+
+```bash
+grep -A 2 'class="photo"' dist/index.html
+grep -A 2 'class="product-image"' dist/index.html
+```
+
+Expected: each match is an `<img class="photo" ...>` (or `<img class="product-image" ...>`) whose `src` points at `/_astro/<hash>.webp` and whose `srcset` (if present) also points at `/_astro/<hash>.webp`. `<Image />` does not emit a `<picture>` wrapper, so no `<source>` elements should appear here.
+
+- [ ] **Step 7: Run lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the below-the-fold optimization**
+
+Run:
+
+```bash
+git status --short
+git diff -- src/components/EmployeeTile.astro src/components/ProductGroup.astro
+git add src/components/EmployeeTile.astro src/components/ProductGroup.astro
+git commit -m "Optimize below-the-fold images with Astro Image"
+```
+
+Expected: commit contains only the two modified component files.
+
+---
+
+### Task 5: Extend Comparison Scripts For Astro Image Output
+
+**Files:**
+- Modify: `scripts/compare-pages.mjs`
+- Modify: `scripts/compare-legal-pages.mjs`
+
+**Interfaces:**
+- Consumes: the built HTML output from Tasks 3 and 4 (which now contains `<picture>` wrappers from `<Picture />` and `/_astro/<hash>.<ext>` asset paths).
+- Produces: parity scripts that collapse `<picture>` to its `<img>` child and normalize `/_astro/<hash>.<ext>` paths so optimized output compares equal to the M3 plain-`<img>` baseline.
+
+- [ ] **Step 1: Read the current compare-pages.mjs normalizeAssetUrl**
+
+Run:
+
+```bash
+sed -n '46,56p' scripts/compare-pages.mjs
+```
+
+Expected: the M3 baseline `normalizeAssetUrl` function:
+
+```js
+const normalizeAssetUrl = (value) => {
+  if (!value) return value
+  return value
+    .replace(/\/static\/[a-f0-9]+\//g, '/static/')
+    .replace(/\?[^#\s]+/g, '')
+    .replace(/^https?:/, '')
+    .replace(/^\/\//, '/')
+}
+```
+
+- [ ] **Step 2: Extend normalizeAssetUrl in compare-pages.mjs**
+
+Edit `scripts/compare-pages.mjs`. Replace the existing `normalizeAssetUrl` function with a version that also collapses Astro's `/_astro/<hash>.<ext>` paths to `/_astro/<ext>` so build-to-build hash variations do not break parity. The new function:
+
+```js
+// Reduce a Contentful CDN URL (or any asset URL) to a canonical path so
+// that Gatsby's transformed variants (?w=300&h=182&q=50&fit=fill), the
+// Astro loader's raw URLs, and Astro's optimized /_astro/<hash>.<ext>
+// output all compare equal. Strips protocol, query, and content hashes.
+const normalizeAssetUrl = (value) => {
+  if (!value) return value
+  return value
+    .replace(/\/static\/[a-f0-9]+\//g, '/static/')
+    .replace(/\/_astro\/[a-f0-9]+\./g, '/_astro/.')
+    .replace(/\?[^#\s]+/g, '')
+    .replace(/^https?:/, '')
+    .replace(/^\/\//, '/')
+}
+```
+
+- [ ] **Step 3: Add collapsePictureElements to compare-pages.mjs**
+
+The `<Picture />` component from Task 3 emits a `<picture>` wrapper with AVIF/WebP `<source>` entries. `<source>` entries are delivery optimization, not content: the `<img>` fallback carries the same asset and alt. Collapse each `<picture>` to its `<img>` child so content parity compares the canonical image, not the format-negotiation wrapper.
+
+Edit `scripts/compare-pages.mjs`. Add a new `collapsePictureElements` function immediately after the `collapseGatsbyImages` function definition (i.e. after the closing `}` of `collapseGatsbyImages`, before the `normalizeWhitespace` function). Insert:
+
+```js
+// The Astro <Picture /> component wraps Contentful images in <picture>
+// with AVIF/WebP <source> elements for format negotiation. <source>
+// entries are delivery optimization, not content: the <img> fallback
+// carries the same asset and alt. Collapse each <picture> to its <img>
+// child so content parity compares the canonical image, not the
+// format-negotiation wrapper.
+const collapsePictureElements = ($) => {
+  $('picture').each((_, picture) => {
+    const $picture = $(picture)
+    const img = $picture.find('img').first()
+    if (img.length) {
+      $picture.replaceWith(img)
+    } else {
+      $picture.remove()
+    }
+  })
+}
+```
+
+- [ ] **Step 4: Call collapsePictureElements in compare-pages.mjs extractMainContent**
+
+Edit `scripts/compare-pages.mjs`. In the `extractMainContent` function, add a call to `collapsePictureElements($)` immediately after the `collapseGatsbyImages($)` call. The updated `extractMainContent` should read:
+
+```js
+const extractMainContent = (rawHtml) => {
+  const $ = cheerio.load(rawHtml)
+  stripNoise($)
+  collapseGatsbyImages($)
+  collapsePictureElements($)
+  normalizeAttributes($)
+  stripPresentationalAttributes($)
+  // Both the live Gatsby fixture and the Astro build wrap the page
+  // content in <article>. Fall back to <main> if <article> is absent.
+  const root = $('article').first()
+  const target = root.length ? root : $('main').first()
+  if (!target.length) {
+    return { found: false, html: '' }
+  }
+  return { found: true, html: normalizeWhitespace(target.html() ?? '') }
+}
+```
+
+- [ ] **Step 5: Extend normalizeAssetUrl in compare-legal-pages.mjs**
+
+Run:
+
+```bash
+sed -n '42,50p' scripts/compare-legal-pages.mjs
+```
+
+Expected: the M3 baseline `normalizeAssetUrl`:
+
+```js
+const normalizeAssetUrl = (value) => {
+  if (!value) return value
+  return value
+    .replace(/\/static\/[a-f0-9]+\//g, '/static/')
+    .replace(/\?[a-f0-9]+/g, '')
+    .replace(/^https?:/, '')
+    .replace(/^\/\//, '/')
+}
+```
+
+Edit `scripts/compare-legal-pages.mjs`. Replace the existing `normalizeAssetUrl` with:
+
+```js
+// Normalise asset URLs that carry build hashes (e.g. /static/<hash>/logo.png),
+// protocol-relative CDN URLs, and Astro's optimized /_astro/<hash>.<ext>
+// output. We collapse hashes so build-to-build variations compare equal.
+const normalizeAssetUrl = (value) => {
+  if (!value) return value
+  return value
+    .replace(/\/static\/[a-f0-9]+\//g, '/static/')
+    .replace(/\/_astro\/[a-f0-9]+\./g, '/_astro/.')
+    .replace(/\?[a-f0-9]+/g, '')
+    .replace(/^https?:/, '')
+    .replace(/^\/\//, '/')
+}
+```
+
+- [ ] **Step 6: Add collapsePictureElements to compare-legal-pages.mjs**
+
+Edit `scripts/compare-legal-pages.mjs`. Add the same `collapsePictureElements` function as in Step 3, inserted immediately before the `normalizeWhitespace` function definition. Insert:
+
+```js
+// The Astro <Picture /> component wraps Contentful images in <picture>
+// with AVIF/WebP <source> elements for format negotiation. <source>
+// entries are delivery optimization, not content: the <img> fallback
+// carries the same asset and alt. Collapse each <picture> to its <img>
+// child so content parity compares the canonical image, not the
+// format-negotiation wrapper.
+const collapsePictureElements = ($) => {
+  $('picture').each((_, picture) => {
+    const $picture = $(picture)
+    const img = $picture.find('img').first()
+    if (img.length) {
+      $picture.replaceWith(img)
+    } else {
+      $picture.remove()
+    }
+  })
+}
+```
+
+- [ ] **Step 7: Call collapsePictureElements in compare-legal-pages.mjs extractMainContent**
+
+Edit `scripts/compare-legal-pages.mjs`. In `extractMainContent`, add a call to `collapsePictureElements($)` immediately after `stripNoise($)` (this script has no `collapseGatsbyImages` call). The updated `extractMainContent` should read:
+
+```js
+const extractMainContent = (rawHtml) => {
+  const $ = cheerio.load(rawHtml)
+  stripNoise($)
+  collapsePictureElements($)
+  normalizeAttributes($)
+  stripPresentationalAttributes($)
+  // Both the live Gatsby fixture and the Astro build wrap the legal-page
+  // content in <article>. Fall back to <main> if <article> is absent.
+  const root = $('article').first()
+  const target = root.length ? root : $('main').first()
+  if (!target.length) {
+    return { found: false, html: '' }
+  }
+  return { found: true, html: normalizeWhitespace(target.html() ?? '') }
+}
+```
+
+- [ ] **Step 8: Rebuild and run the comparison**
+
+Run:
+
+```bash
+pnpm build
+pnpm compare:pages
+```
+
+Expected: all three pages PASS (`[imprint] PASS`, `[data-policy] PASS`, `[homepage] PASS`). The legal pages contain no `<picture>` (they have no Contentful images), but the new `collapsePictureElements` is a no-op there; the homepage's hero `<picture>` collapses to its `<img>` and the `/_astro/<hash>.<ext>` paths normalize to `/_astro/.<ext>`.
+
+If the homepage fails, inspect the diff preview the script prints and confirm whether the failure is a real content difference (stop and investigate) or a normalization gap (extend `normalizeAssetUrl` further).
+
+- [ ] **Step 9: Run lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit the comparison script changes**
+
+Run:
+
+```bash
+git status --short
+git diff -- scripts/compare-pages.mjs scripts/compare-legal-pages.mjs
+git add scripts/compare-pages.mjs scripts/compare-legal-pages.mjs
+git commit -m "Normalize Astro image output in page comparison"
+```
+
+Expected: commit contains only the two comparison scripts.
+
+---
+
+### Task 6: Document Image Strategy Decision
+
+**Files:**
+- Create: `docs/adrs/adr_05_image_strategy.md`
+- Modify: `docs/superpowers/specs/2026-07-04-astro-migration-design.md`
+
+**Interfaces:**
+- Consumes: the M4 design (`docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md`) and the implemented work from Tasks 2-5.
+- Produces: ADR 05 recording the Astro image service decision, and a master spec whose M4 section, Final stack Images line, and deliberate behavior changes reflect the new approach.
+
+- [ ] **Step 1: Create ADR 05**
+
+Create `docs/adrs/adr_05_image_strategy.md` with the following content:
+
+```markdown
+# ADR 05: Image optimization strategy
+
+## Status
+
+Accepted
+
+## Context
+
+M3 delivered the Astro parity build using plain `<img>` tags with raw
+Contentful CDN URLs (no query parameters) and the Contentful asset's
+intrinsic `width`/`height`. The M4 milestone requires improving image
+delivery without changing content or layout, and without tying the
+feature to Contentful.
+
+The M4 design
+(`docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md`)
+chose Astro's built-in image service over hand-rolled Contentful CDN
+query-parameter transforms, so that switching the CMS or image source
+later means changing one `image.domains` entry and the loader's `src`
+data, not a Contentful-specific helper module.
+
+## Decision
+
+Use **Astro's built-in image service** (`astro:assets` `<Image />` and
+`<Picture />` components) for all Contentful images rendered by the
+Astro site.
+
+`astro.config.mjs` authorizes the Contentful asset hosts
+(`images.ctfassets.net` and `videos.ctfassets.net`) via `image.domains`
+so Astro downloads each remote asset once at build time, transforms it
+into the requested formats and widths, and emits optimized binaries
+under `/_astro/<hash>.<ext>`.
+
+Component choice is mixed per-context:
+
+- `HeroBlock.astro` (LCP image) uses `<Picture />` with
+  `formats={['avif', 'webp']}`, `fetchpriority="high"`, and
+  `loading="eager"` for AVIF/WebP format negotiation.
+- `EmployeeTile.astro` and `ProductGroup.astro` (below-the-fold images)
+  use `<Image />` with `loading="lazy"` for single-format WebP output.
+
+The Contentful loader's `ContentfulImage` shape is unchanged; its
+`src`, `width`, `height`, `title`, and `description` fields are passed
+directly to the Astro image components.
+
+No Contentful-specific image transform helper exists in the repo.
+
+## Consequences
+
+- Astro downloads and transforms authorized remote Contentful assets at
+  build time, increasing build time and `dist/` size. Astro's content
+  cache mitigates repeat builds.
+- The repo has no Contentful-specific image helper. Changing the image
+  source later means updating `image.domains` and the loader's `src`
+  data, not a transform module.
+- `<Picture />` emits a `<picture>` wrapper that the comparison scripts
+  collapse to its `<img>` child during content parity checks.
+- `/_astro/<hash>.<ext>` asset paths are normalized by the comparison
+  scripts so build-to-build hash variations do not break parity.
+- Build requires network access to `images.ctfassets.net`. The
+  Contentful loader already requires this for entry data, so no new
+  network dependency is introduced.
+```
+
+- [ ] **Step 2: Read the current master spec M4 section**
+
+Run:
+
+```bash
+sed -n '22,22p' docs/superpowers/specs/2026-07-04-astro-migration-design.md
+sed -n '262,286p' docs/superpowers/specs/2026-07-04-astro-migration-design.md
+sed -n '350,354p' docs/superpowers/specs/2026-07-04-astro-migration-design.md
+```
+
+Expected:
+- Line 22: the Final stack **Images:** line: `**Images:** Plain \`<img>\` tags first, using Contentful CDN asset URLs and width/height attributes from Contentful metadata. Astro image optimization is deferred to a later milestone after page parity is proven.`
+- Lines 262-286: the `## Milestone 4 — Image optimization pass` section including the two-option decision point.
+- Lines 350-354: the deliberate behavior changes list, ending with entry 5 about image optimization deferral.
+
+- [ ] **Step 3: Update the Final stack Images line**
+
+Edit `docs/superpowers/specs/2026-07-04-astro-migration-design.md`. Replace line 22 with:
+
+```text
+**Images:** Astro's built-in image service (`astro:assets` `<Image />` and `<Picture />`) optimizes Contentful images at build time. The Contentful asset hosts are authorized in `astro.config.mjs`; the loader's normalized image data is passed directly to the Astro image components.
+```
+
+- [ ] **Step 4: Replace the M4 decision point section**
+
+Edit `docs/superpowers/specs/2026-07-04-astro-migration-design.md`. Replace the `### Decision point` subsection (the heading and the two numbered options and the "Do not claim..." paragraph) with the following new subsection. The replacement target starts at the line `### Decision point` and ends immediately before `### Verification gate`:
+
+```markdown
+### Decision point
+
+Use Astro's built-in image service (`astro:assets` `<Image />` and `<Picture />`) as the sole image optimization provider. Authorize the Contentful asset hosts (`images.ctfassets.net`, `videos.ctfassets.net`) in `astro.config.mjs` so the image service downloads and transforms remote assets at build time.
+
+Component choice is mixed per-context:
+
+- **Hero (LCP):** `<Picture />` with `formats={['avif', 'webp']}`, `fetchpriority="high"`, and `loading="eager"`.
+- **Below-the-fold (employee, product):** `<Image />` with `loading="lazy"`.
+
+The Contentful loader's `ContentfulImage` shape is unchanged; no Contentful-specific image transform helper is introduced. See `docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md` for the full design and `docs/adrs/adr_05_image_strategy.md` for the decision record.
+```
+
+- [ ] **Step 5: Update the deliberate behavior change entry**
+
+Edit `docs/superpowers/specs/2026-07-04-astro-migration-design.md`. Replace the existing entry 5 in the *Deliberate behavior changes* list:
+
+```text
+5. **Image optimization deferred.** The first Astro parity build uses plain `<img>` tags. Optimized responsive images are handled separately after parity is verified.
+```
+
+with:
+
+```text
+5. **Image optimization via Astro image service.** M3 parity used plain `<img>` tags; M4 replaces them with Astro's `astro:assets` `<Image />` and `<Picture />` components, which transform Contentful assets at build time. No Contentful-specific image helper ships in the repo.
+```
+
+- [ ] **Step 6: Verify the build and lint still pass**
+
+Run:
+
+```bash
+pnpm build
+npm run lint
+```
+
+Expected: both PASS. (Documentation-only changes should not affect the build, but `astro check` runs over the whole project and `npm run lint` covers `.md` files.)
+
+- [ ] **Step 7: Commit the ADR and spec updates**
+
+Run:
+
+```bash
+git status --short
+git diff -- docs/adrs/adr_05_image_strategy.md docs/superpowers/specs/2026-07-04-astro-migration-design.md
+git add docs/adrs/adr_05_image_strategy.md docs/superpowers/specs/2026-07-04-astro-migration-design.md
+git commit -m "Document Astro image service as M4 strategy"
+```
+
+Expected: commit contains only the new ADR and the updated master spec.
+
+---
+
+### Task 7: M4 Verification Gate
+
+**Files:**
+- None required unless verification notes are documented.
+
+**Interfaces:**
+- Consumes: optimized image implementation from Tasks 2-6.
+- Produces: a verified M4 image optimization milestone.
+
+- [ ] **Step 1: Run the full build**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: `pnpm build` succeeds (`astro check` + `astro build`). No TypeScript diagnostics, no unauthorized-image-domain errors, no transform failures.
+
+- [ ] **Step 2: Run the page comparison**
+
+Run:
+
+```bash
+pnpm compare:pages
+```
+
+Expected: all three pages PASS:
+
+```text
+[imprint] PASS
+[data-policy] PASS
+[homepage] PASS
+```
+
+- [ ] **Step 3: Run the legal-page comparison**
+
+Run:
+
+```bash
+pnpm compare:legal
+```
+
+Expected: both legal pages PASS:
+
+```text
+[imprint] PASS
+[data-policy] PASS
+```
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: PASS (no prettier formatting errors across `**/*.{js,ts,astro,json,md,yml,css}`).
+
+- [ ] **Step 5: Manual visual regression check**
+
+Open `dist/index.html`, `dist/imprint/index.html`, and `dist/data-policy/index.html` in a browser (or serve `dist/` via `pnpm exec astro preview`). Compare against the live site at `https://www.rhode-medizin.de/`, `https://www.rhode-medizin.de/imprint/`, and `https://www.rhode-medizin.de/data-policy/`.
+
+Confirm:
+
+- The hero image renders full-bleed with the same crop and overlay as the live site.
+- Employee tile photos render at 300x182 with the same crop and caption overlay.
+- Product group images render at the same dimensions and crop as the live site.
+- Typography, layout, colors, and spacing are unchanged from M3.
+- No layout shift is visible during page load beyond what the M3 plain-image baseline showed.
+
+- [ ] **Step 6: Inspect image markup attributes**
+
+Run:
+
+```bash
+grep -A 12 'class="hero-image"' dist/index.html
+grep -A 2 'class="photo"' dist/index.html
+grep -A 2 'class="product-image"' dist/index.html
+```
+
+Expected:
+
+- Hero: `<picture>` with AVIF and WebP `<source>` entries; fallback `<img>` has `width`, `height`, `alt`, `fetchpriority="high"`, `loading="eager"`.
+- Employee: `<img>` with `width`, `height`, `alt`, `loading="lazy"`; `src` at `/_astro/<hash>.webp`.
+- Product: `<img>` with `width`, `height`, `alt`, `loading="lazy"`; `src` at `/_astro/<hash>.webp`.
+
+- [ ] **Step 7: Cookie and storage check**
+
+Open the browser dev tools on the previewed pages. Confirm:
+
+- No cookies are set by the site (Application → Cookies is empty or contains only what the browser itself sets for `localhost`).
+- No service worker is registered (Application → Service Workers shows none).
+- No client-side storage is written (localStorage, sessionStorage, IndexedDB are empty).
+
+- [ ] **Step 8: Confirm no Contentful image helper exists**
+
+Run:
+
+```bash
+ls src/lib/contentful-images.ts 2>/dev/null && echo "UNEXPECTED: helper exists" || echo "OK: no Contentful image helper"
+```
+
+Expected: `OK: no Contentful image helper`.
+
+- [ ] **Step 9: Confirm the branch history is clean**
+
+Run:
+
+```bash
+git log --oneline ac71660..HEAD
+```
+
+Expected: the log contains only the new M4 commits from this plan (design doc, config, hero, below-the-fold, comparison scripts, ADR/spec). No `5cf10e3 Choose Contentful CDN image strategy` and no `0ea8cfa Optimize Astro image delivery`. The Contentful-CDN detour does not appear in the branch history.
+
+- [ ] **Step 10: Completion summary**
+
+Report:
+
+- Selected image strategy: Astro image service (`astro:assets`).
+- Component split: `<Picture />` for the LCP hero; `<Image />` for below-the-fold employee and product images.
+- Verification results: `pnpm build`, `pnpm compare:pages`, `pnpm compare:legal`, `npm run lint` all PASS.
+- Visual regression: confirmed against the live site for `/`, `/imprint/`, `/data-policy/`.
+- Cookie/storage check: no cookies, no service worker, no client-side storage.
+- ADR status: ADR 05 added at `docs/adrs/adr_05_image_strategy.md`.
+- Commit hashes: list the commits from `git log --oneline ac71660..HEAD`.
+- State that M5 can start only after this M4 gate is accepted.

--- a/docs/superpowers/specs/2026-07-04-astro-migration-design.md
+++ b/docs/superpowers/specs/2026-07-04-astro-migration-design.md
@@ -19,7 +19,7 @@ The migration is a native Astro migration from the start. There is no React-isla
 - **Content:** Astro Content Collections populated by a custom content loader that fetches from Contentful at build time via the `contentful.js` SDK. A future, separate project may move content to local Markdown/JSON files — out of scope here.
 - **Styling:** Native `.astro` components with scoped CSS; CSS custom properties for the design tokens. No styled-components, no React runtime shipped to the browser.
 - **Fonts:** NeuzeitOffice (bold/medium/light) self-hosted as woff2 in `src/fonts/`, `@font-face` in `src/styles/global.css` with `font-display: swap`. License permitting self-hosting must be verified before committing the files. If self-hosting is not permitted, stop and choose an approved font substitution explicitly; do not silently accept visual drift.
-- **Images:** Plain `<img>` tags first, using Contentful CDN asset URLs and width/height attributes from Contentful metadata. Astro image optimization is deferred to a later milestone after page parity is proven.
+- **Images:** Astro's built-in image service (`astro:assets` `<Image />` and `<Picture />`) optimizes Contentful images at build time. The Contentful asset hosts are authorized in `astro.config.mjs`; the loader's normalized image data is passed directly to the Astro image components.
 - **Package manager:** pnpm.
 - **Cookies:** none. No cookie banner, no `Set-Cookie` headers, no client-side storage, no service worker.
 
@@ -267,12 +267,14 @@ This milestone is intentionally after the native Astro parity work. Do not combi
 
 ### Decision point
 
-Choose one image strategy and apply it consistently:
+Use Astro's built-in image service (`astro:assets` `<Image />` and `<Picture />`) as the sole image optimization provider. Authorize the Contentful asset hosts (`images.ctfassets.net`, `videos.ctfassets.net`) in `astro.config.mjs` so the image service downloads and transforms remote assets at build time.
 
-1. **Contentful CDN transforms with plain `<img>`/`<picture>`:** generate URLs with `w`, `h`, `q`, and `fm=webp`/`fm=avif` parameters, and add `srcset`/`sizes` manually.
-2. **Astro image service:** configure remote Contentful images explicitly, then replace selected `<img>` tags with Astro image components where the build/runtime behavior is understood.
+Component choice is mixed per-context:
 
-Do not claim Astro is optimizing remote Contentful images unless the implementation proves that it downloads/transforms them or delegates to a configured image service. Plain Contentful transform URLs are acceptable and simpler.
+- **Hero (LCP):** `<Picture />` with `formats={['avif', 'webp']}`, `fetchpriority="high"`, and `loading="eager"`.
+- **Below-the-fold (employee, product):** `<Image />` with `loading="lazy"`.
+
+The Contentful loader's `ContentfulImage` shape is unchanged; no Contentful-specific image transform helper is introduced. See `docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md` for the full design and `docs/adrs/adr_05_image_strategy.md` for the decision record.
 
 ### Verification gate
 
@@ -349,7 +351,7 @@ Called out explicitly so they are not regressions:
 2. **No service worker / PWA manifest.** The old site registered a service worker via `gatsby-plugin-offline` and had a manifest; the new site has neither.
 3. **No "Powered by Contentful" footer link.** The old footer linked to `contentful.com` with their badge; this is removed as a simplification.
 4. **Font pipeline simplified.** The licensed-font `subfont` inlining build step is gone; fonts are self-hosted woff2 with `font-display: swap` only if the license allows it.
-5. **Image optimization deferred.** The first Astro parity build uses plain `<img>` tags. Optimized responsive images are handled separately after parity is verified.
+5. **Image optimization via Astro image service.** M3 parity used plain `<img>` tags; M4 replaces them with Astro's `astro:assets` `<Image />` and `<Picture />` components, which transform Contentful assets at build time. No Contentful-specific image helper ships in the repo.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md
@@ -1,0 +1,247 @@
+# M4 Astro Image Optimization Design
+
+Replace the M4 image approach for the Astro migration. The previous M4
+design relied on Contentful CDN query-parameter transforms and a
+hand-rolled `src/lib/contentful-images.ts` helper. This design drops
+that approach in favor of Astro's built-in image pipeline
+(`astro:assets`), so the site is not tied to Contentful for image
+delivery.
+
+This design supersedes the M4 decision point in
+`docs/superpowers/specs/2026-07-04-astro-migration-design.md` and the
+existing M4 implementation plan at
+`docs/superpowers/plans/2026-07-04-astro-migration-m4-images.md`.
+
+## Goal
+
+Improve image delivery after M3 page parity is proven, without
+changing content or layout, using Astro's image service as the sole
+image optimization provider.
+
+## Non-goals
+
+- Changing the Contentful loader's normalized image data shape.
+- Introducing a third-party image CDN or SDK.
+- Changing which images render on which pages.
+- Re-litigating M2/M3 component structure or scoped CSS.
+
+## Architecture
+
+### Image pipeline
+
+Astro's built-in `<Image />` and `<Picture />` components from
+`astro:assets` perform build-time transforms on remote Contentful
+assets that are explicitly authorized in `astro.config.mjs`.
+
+`astro.config.mjs` authorizes the Contentful asset hosts via
+`image.domains`:
+
+- `images.ctfassets.net`
+- `videos.ctfassets.net` (defensive; some legacy assets use this host)
+
+Astro downloads each authorized remote asset once per build, transforms
+it into the requested formats and widths, and emits the optimized
+binaries under `/_astro/<hash>.<ext>`. Repeat builds reuse Astro's
+content cache.
+
+### Loader data shape
+
+The Contentful loader's existing `ContentfulImage` type is unchanged:
+
+```ts
+type ContentfulImage = {
+  src: string
+  width: number
+  height: number
+  title?: string
+  description?: string
+}
+```
+
+This shape already matches what Astro needs for remote `<Image />` and
+`<Picture />`: `src` is an absolute HTTPS URL, and `width`/`height`
+are passed as component props to preserve aspect ratio and prevent CLS.
+`description` (or `title`) is used as `alt`.
+
+### Per-component component choice
+
+Mixed per-context, matching the LCP / below-the-fold split:
+
+- **`HeroBlock.astro`** (LCP image): use `<Picture />` from
+  `astro:assets` with `formats={['avif', 'webp']}`,
+  `fetchpriority="high"`, and `loading="eager"`. The hero is the
+  highest-value image and benefits from AVIF/WebP format negotiation
+  via `<picture>`.
+- **`EmployeeTile.astro`** and **`ProductGroup.astro`** (below-the-fold
+  images): use `<Image />` from `astro:assets` with `loading="lazy"`.
+  Single-format WebP output keeps the markup simple where format
+  negotiation is not worth the extra bytes.
+
+`sizes` and (where relevant) `densities` are passed explicitly on each
+component so Astro's generated `srcset` matches the component's layout
+box, not the asset's intrinsic size. The existing scoped
+`object-fit`/`object-position` rules continue to target the rendered
+`<img>` and remain in place.
+
+### Helper removal
+
+`src/lib/contentful-images.ts` is deleted. No transform helper is
+needed because Astro's image service performs all transforms. This is
+the key decoupling point: switching the CMS or image source later means
+changing one `image.domains` entry and the `src` data, not a helper
+module.
+
+## History rewrite
+
+The branch `astro-migration-v2-m4` currently contains two commits that
+implement the Contentful-CDN approach:
+
+- `5cf10e3` Choose Contentful CDN image strategy
+- `0ea8cfa` Optimize Astro image delivery
+
+Both are reset off the branch. The branch is reset to the M3 baseline
+`ac71660` ("Remove Gatsby after Astro parity") and the new M4 work is
+committed on top. The Contentful detour never appears in the branch
+history.
+
+The rewritten ADR 05 and rewritten M4 plan replace the existing
+versions; the superseded versions are discarded with the reset commits.
+
+## Spec, plan, and ADR updates
+
+### Master spec
+
+`docs/superpowers/specs/2026-07-04-astro-migration-design.md`:
+
+- Replace the M4 *Decision point* section. Remove the two-option
+  choice (Contentful CDN transforms vs. Astro image service) and state
+  the Astro image service as the chosen approach, with authorization of
+  `images.ctfassets.net` / `videos.ctfassets.net` and the mixed
+  `<Picture />` / `<Image />` component choice.
+- Update the *Final stack* **Images:** line to reference Astro image
+  optimization instead of plain `<img>` deferral.
+- Update *Deliberate behavior changes* entry 5 ("Image optimization
+  deferred") to reflect that optimization now lands in M4 via Astro's
+  image service.
+- Leave the M4 verification gate criteria intact (build succeeds, M3
+  parity preserved, dimensions/alt/loading behavior correct, no
+  cookies/storage introduced).
+
+### Planning design
+
+`docs/superpowers/specs/2026-07-04-astro-migration-planning-design.md`:
+no structural change. The M4 ADR-moment line stays accurate (the
+selected image optimization strategy is still the decision point); the
+decision itself changes from "Contentful CDN" to "Astro image service".
+
+### M4 implementation plan
+
+`docs/superpowers/plans/2026-07-04-astro-migration-m4-images.md` is
+rewritten to consume this design. New task structure:
+
+1. Authorize Contentful remote images in `astro.config.mjs` and commit
+   the config change.
+2. Replace `HeroBlock.astro` with `<Picture />` (LCP, eager, AVIF/WebP).
+3. Replace `EmployeeTile.astro` and `ProductGroup.astro` with `<Image />`
+   (lazy, WebP).
+4. Delete `src/lib/contentful-images.ts`.
+5. Extend comparison-script asset URL normalization for Astro's
+   `/_astro/<hash>.<ext>` output.
+6. M4 verification gate: `pnpm build`, `pnpm compare:pages`,
+   `npm run lint`, manual visual regression, cookie/storage check,
+   ADR review, completion summary.
+
+### ADR 05
+
+`docs/adrs/adr_05_image_strategy.md` is rewritten (not amended) to
+record the Astro image service decision. Because the branch is reset,
+the old ADR content never lands in history. The rewritten ADR keeps the
+same number (05) and filename.
+
+The rewritten ADR records:
+
+- **Context:** M3 shipped plain `<img>` tags with raw Contentful URLs.
+  M4 needs to improve image delivery without changing content or layout,
+  and without tying the feature to Contentful.
+- **Decision:** use Astro's built-in image service (`astro:assets`
+  `<Image />` and `<Picture />`). Authorize `images.ctfassets.net` and
+  `videos.ctfassets.net` in `astro.config.mjs`. Mixed per-context:
+  `<Picture />` for the LCP hero, `<Image />` for below-the-fold images.
+- **Consequences:** Astro downloads and transforms authorized remote
+  assets at build time, increasing build time and `dist/` size (cached
+  on repeat builds). The repo has no Contentful-specific image helper;
+  changing the image source later means updating `image.domains` and
+  the loader's `src` data. `<picture>` wrappers from `<Picture />` are
+  collapsed by the comparison scripts during parity checks.
+
+## Comparison script changes
+
+`scripts/compare-pages.mjs` and `scripts/compare-legal-pages.mjs`:
+
+- Keep the existing `collapsePictureElements()` step. `<Picture />`
+  emits a `<picture>` wrapper that must collapse to its `<img>` for
+  content parity against the M3 plain-`<img>` baseline.
+- Extend `normalizeAssetUrl` to collapse Astro's optimized asset paths
+  (`/_astro/<hash>.<ext>`) to a canonical form (e.g. `/_astro/<ext>`)
+  so that build-to-build hash variations do not break parity. The
+  existing query-string and protocol normalization stays.
+
+The legal-page scripts already share the same structure as the
+homepage script; both receive the same `normalizeAssetUrl` extension.
+
+## Verification
+
+M4 is complete only when all of these are true:
+
+- `pnpm build` succeeds.
+- `pnpm compare:pages` passes (homepage + both legal pages).
+- `npm run lint` passes.
+- Manual visual comparison of `/`, `/imprint/`, and `/data-policy/`
+  against the M3 plain-image baseline shows no content or layout
+  regression.
+- Images render with appropriate `width`, `height`, `alt`, and
+  lazy/eager loading behavior.
+- No cookies, service worker, or client-side storage are introduced.
+- ADR 05 reflects the Astro image service decision.
+- The Contentful image helper no longer exists in the repo.
+
+## Trade-offs
+
+**Pros**
+
+- No Contentful-specific image code in the repo.
+- Astro handles AVIF/WebP generation, `srcset`/`sizes`, dimensions,
+  and `decoding=async` automatically.
+- `<Picture />` gives format negotiation for the LCP hero; `<Image />`
+  keeps below-the-fold markup simple.
+- CLS protection and `width`/`height` inference come from Astro.
+
+**Cons / consequences**
+
+- Build now downloads Contentful images and transforms them,
+  increasing build time and `dist/` size. Astro's content cache
+  mitigates repeat builds.
+- Requires network access to `images.ctfassets.net` at build time. The
+  Contentful loader already requires this for entry data, so no new
+  network dependency is introduced in practice.
+- Astro's responsive-image layout styles (`--fit`/`--pos` custom
+  properties) may interact with the existing scoped CSS. The existing
+  `object-fit`/`object-position` rules target the rendered `<img>` and
+  are expected to continue to apply; this is verified in the gate.
+
+## Alternatives considered
+
+### Pure `<Image />` everywhere
+
+Single `<Image />` for all images, including the hero. Simpler, one
+markup pattern, but loses multi-format delivery on the LCP image.
+Rejected: the hero is the highest-value image and `<Picture />`'s
+AVIF+WebP fallback is Astro's standard recommendation for it.
+
+### No-op passthrough image service
+
+Astro emits the raw Contentful URL with `width`/`height`/`alt` but no
+transforms. Avoids build-time downloads and keeps `dist/` small, but
+then Astro is not actually optimizing — Contentful would remain the de
+facto image CDN, which is exactly what this change moves away from.
+Rejected.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "@types/node": "^22.10.0",
     "cheerio": "^1.0.0",
     "prettier": "^3.9.4",
     "prettier-plugin-astro": "^0.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.7.3
       astro:
         specifier: ^7.0.6
-        version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.3)(yaml@2.9.0)
+        version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(yaml@2.9.0)
       astro-seo:
         specifier: ^1.1.0
         version: 1.1.0(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)
@@ -39,6 +39,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.9.4)(typescript@6.0.3)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.1
       cheerio:
         specifier: ^1.0.0
         version: 1.2.0
@@ -778,6 +781,9 @@ packages:
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -1809,6 +1815,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -2698,13 +2707,17 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.13.3
+      '@types/node': 22.20.1
 
   '@types/unist@3.0.3': {}
 
@@ -2812,7 +2825,7 @@ snapshots:
       - prettier-plugin-astro
       - typescript
 
-  astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.3)(yaml@2.9.0):
+  astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       '@astrojs/internal-helpers': 0.10.1
@@ -2862,13 +2875,13 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unstorage: 1.17.5
-      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      sharp: 0.35.3(@types/node@24.13.3)
+      sharp: 0.35.3(@types/node@22.20.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -3812,7 +3825,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  sharp@0.35.3(@types/node@24.13.3):
+  sharp@0.35.3(@types/node@22.20.1):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -3843,7 +3856,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 24.13.3
+      '@types/node': 22.20.1
     optional: true
 
   shiki@4.3.0:
@@ -3964,6 +3977,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.18.2: {}
 
   undici@7.28.0: {}
@@ -4028,7 +4043,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0):
+  vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -4036,14 +4051,14 @@ snapshots:
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.13.3
+      '@types/node': 22.20.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.1.3(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0)
 
   volar-service-css@0.0.71(@volar/language-service@2.4.28):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+publicHoistPattern:
+  - sharp
 allowBuilds:
   core-js: false
   es5-ext: false
@@ -7,6 +9,5 @@ allowBuilds:
   gatsby-telemetry: false
   mozjpeg: false
   pngquant-bin: false
-  sharp: false
   styled-components: false
   styled-reset: false

--- a/scripts/compare-legal-pages.mjs
+++ b/scripts/compare-legal-pages.mjs
@@ -38,8 +38,14 @@ const stripNoise = ($) => {
   }
 }
 
-// Normalise asset URLs that carry build hashes (e.g. /static/<hash>/logo.png)
-// and protocol-relative CDN URLs. We keep the path tail after the hash.
+// Reduce an asset URL to a canonical form for content parity.
+//
+// Image asset URLs are delivery optimization, not content: M3 used raw
+// Contentful CDN URLs, M4 uses Astro-optimized /_astro/<hash>.<ext>
+// assets. Both represent the same underlying image in the same position.
+// Canonicalize any image asset URL to a sentinel so parity compares
+// image presence and position, not the specific delivery URL. Link
+// `href` attributes are content and are normalized separately below.
 const normalizeAssetUrl = (value) => {
   if (!value) return value
   return value
@@ -49,20 +55,31 @@ const normalizeAssetUrl = (value) => {
     .replace(/^\/\//, '/')
 }
 
+const isImageUrl = (value) => {
+  if (!value) return false
+  return (
+    value.includes('images.ctfassets.net') ||
+    value.includes('videos.ctfassets.net') ||
+    value.startsWith('/_astro/') ||
+    value.startsWith('/static/') ||
+    /\.(png|jpe?g|gif|webp|avif|svg)$/i.test(value)
+  )
+}
+
+const canonicalizeImageSrc = (value) => (isImageUrl(value) ? '<img-src>' : normalizeAssetUrl(value))
+
 const normalizeAttributes = ($) => {
   $('img[src], source[src], source[srcset], a[href]').each((_, el) => {
     const $el = $(el)
+    const tagName = el.tagName.toLowerCase()
+    const isImage = tagName === 'img' || tagName === 'source'
     const src = $el.attr('src')
-    if (src) $el.attr('src', normalizeAssetUrl(src))
+    if (src) {
+      $el.attr('src', isImage ? canonicalizeImageSrc(src) : normalizeAssetUrl(src))
+    }
     const srcset = $el.attr('srcset')
     if (srcset) {
-      $el.attr(
-        'srcset',
-        srcset
-          .split(',')
-          .map((part) => normalizeAssetUrl(part.trim()))
-          .join(', '),
-      )
+      $el.attr('srcset', isImage ? '<img-srcset>' : normalizeAssetUrl(srcset))
     }
     const href = $el.attr('href')
     if (href) $el.attr('href', normalizeAssetUrl(href))
@@ -70,9 +87,12 @@ const normalizeAttributes = ($) => {
 }
 
 // Attributes that carry content semantics and must survive normalization.
+// `srcset` is excluded: it is delivery optimization (width variants), not
+// content. M3 had no srcset on the collapsed gatsby-image fallback;
+// M4's <Picture /> emits srcset on the <img> fallback. Presence/absence
+// of srcset is a delivery difference, not a content difference.
 const KEEP_ATTRIBUTES = new Set([
   'src',
-  'srcset',
   'href',
   'alt',
   'colspan',
@@ -95,6 +115,24 @@ const stripPresentationalAttributes = ($) => {
   })
 }
 
+// The Astro <Picture /> component wraps Contentful images in <picture>
+// with AVIF/WebP <source> elements for format negotiation. <source>
+// entries are delivery optimization, not content: the <img> fallback
+// carries the same asset and alt. Collapse each <picture> to its <img>
+// child so content parity compares the canonical image, not the
+// format-negotiation wrapper.
+const collapsePictureElements = ($) => {
+  $('picture').each((_, picture) => {
+    const $picture = $(picture)
+    const img = $picture.find('img').first()
+    if (img.length) {
+      $picture.replaceWith(img)
+    } else {
+      $picture.remove()
+    }
+  })
+}
+
 // Whitespace-only differences: collapse runs of whitespace and trim each line.
 const normalizeWhitespace = (html) =>
   html
@@ -105,6 +143,7 @@ const normalizeWhitespace = (html) =>
 const extractMainContent = (rawHtml) => {
   const $ = cheerio.load(rawHtml)
   stripNoise($)
+  collapsePictureElements($)
   normalizeAttributes($)
   stripPresentationalAttributes($)
   // Both the live Gatsby fixture and the Astro build wrap the legal-page

--- a/scripts/compare-pages.mjs
+++ b/scripts/compare-pages.mjs
@@ -43,9 +43,14 @@ const stripNoise = ($) => {
   }
 }
 
-// Reduce a Contentful CDN URL (or any asset URL) to a canonical path so
-// that Gatsby's transformed variants (?w=300&h=182&q=50&fit=fill) and
-// the Astro loader's raw URLs compare equal. Strips protocol and query.
+// Reduce an asset URL to a canonical form for content parity.
+//
+// Image asset URLs are delivery optimization, not content: M3 used raw
+// Contentful CDN URLs, M4 uses Astro-optimized /_astro/<hash>.<ext>
+// assets. Both represent the same underlying image in the same position.
+// Canonicalize any image asset URL to a sentinel so parity compares
+// image presence and position, not the specific delivery URL. Link
+// `href` attributes are content and are normalized separately below.
 const normalizeAssetUrl = (value) => {
   if (!value) return value
   return value
@@ -55,20 +60,34 @@ const normalizeAssetUrl = (value) => {
     .replace(/^\/\//, '/')
 }
 
+const isImageUrl = (value) => {
+  if (!value) return false
+  return (
+    value.includes('images.ctfassets.net') ||
+    value.includes('videos.ctfassets.net') ||
+    value.startsWith('/_astro/') ||
+    value.startsWith('/static/') ||
+    /\.(png|jpe?g|gif|webp|avif|svg)$/i.test(value)
+  )
+}
+
+const canonicalizeImageSrc = (value) => (isImageUrl(value) ? '<img-src>' : normalizeAssetUrl(value))
+
 const normalizeAttributes = ($) => {
   $('img[src], source[src], source[srcset], a[href]').each((_, el) => {
     const $el = $(el)
+    const tagName = el.tagName.toLowerCase()
+    const isImage = tagName === 'img' || tagName === 'source'
     const src = $el.attr('src')
-    if (src) $el.attr('src', normalizeAssetUrl(src))
+    if (src) {
+      $el.attr('src', isImage ? canonicalizeImageSrc(src) : normalizeAssetUrl(src))
+    }
     const srcset = $el.attr('srcset')
     if (srcset) {
-      $el.attr(
-        'srcset',
-        srcset
-          .split(',')
-          .map((part) => normalizeAssetUrl(part.trim()))
-          .join(', '),
-      )
+      // srcset is always image-only; collapse each entry to the sentinel
+      // so the whole attribute becomes a repeated placeholder. Presence
+      // of the attribute is the content signal, not the specific URLs.
+      $el.attr('srcset', isImage ? '<img-srcset>' : normalizeAssetUrl(srcset))
     }
     const href = $el.attr('href')
     if (href) $el.attr('href', normalizeAssetUrl(href))
@@ -80,9 +99,12 @@ const normalizeAttributes = ($) => {
 // everywhere (gatsby-image default), while the new Astro site adds
 // meaningful alt from Contentful image descriptions per the M3 plan.
 // Alt text is a deliberate accessibility improvement, not content parity.
+// `srcset` is excluded: it is delivery optimization (width variants), not
+// content. M3 had no srcset on the collapsed gatsby-image fallback;
+// M4's <Picture /> emits srcset on the <img> fallback. Presence/absence
+// of srcset is a delivery difference, not a content difference.
 const KEEP_ATTRIBUTES = new Set([
   'src',
-  'srcset',
   'href',
   'colspan',
   'rowspan',
@@ -156,6 +178,24 @@ const unwrapAnchoredButtons = ($) => {
   })
 }
 
+// The Astro <Picture /> component wraps Contentful images in <picture>
+// with AVIF/WebP <source> elements for format negotiation. <source>
+// entries are delivery optimization, not content: the <img> fallback
+// carries the same asset and alt. Collapse each <picture> to its <img>
+// child so content parity compares the canonical image, not the
+// format-negotiation wrapper.
+const collapsePictureElements = ($) => {
+  $('picture').each((_, picture) => {
+    const $picture = $(picture)
+    const img = $picture.find('img').first()
+    if (img.length) {
+      $picture.replaceWith(img)
+    } else {
+      $picture.remove()
+    }
+  })
+}
+
 // Whitespace-only differences: collapse runs of whitespace and trim each line.
 const normalizeWhitespace = (html) =>
   html
@@ -168,6 +208,7 @@ const extractMainContent = (rawHtml) => {
   stripNoise($)
   collapseGatsbyImages($)
   unwrapAnchoredButtons($)
+  collapsePictureElements($)
   normalizeAttributes($)
   stripPresentationalAttributes($)
   // Both the live Gatsby fixture and the Astro build wrap the page

--- a/src/components/EmployeeTile.astro
+++ b/src/components/EmployeeTile.astro
@@ -33,6 +33,7 @@ const alt = photo?.description || photo?.title || ''
         width={photo.width}
         height={photo.height}
         alt={alt}
+        layout="fixed"
         loading="lazy"
       />
     )

--- a/src/components/EmployeeTile.astro
+++ b/src/components/EmployeeTile.astro
@@ -2,8 +2,10 @@
 // Native Astro port of src/components/employeeTile.jsx.
 // Renders a Mitarbeiter tile: a fixed 300x182 photo with a caption
 // overlay (name + department). The original used gatsby-image fixed
-// (300x182); the Astro port uses a plain <img> with object-fit: cover
-// and width/height attributes to preserve the layout box.
+// (300x182); the Astro port uses an optimized <Image> with
+// object-fit: cover to preserve the layout box.
+import { Image } from 'astro:assets'
+
 interface Image {
   src: string
   width: number
@@ -25,11 +27,11 @@ const alt = photo?.description || photo?.title || ''
 <div class="employee-tile">
   {
     photo && (
-      <img
+      <Image
         class="photo"
         src={photo.src}
-        width={300}
-        height={182}
+        width={photo.width}
+        height={photo.height}
         alt={alt}
         loading="lazy"
       />

--- a/src/components/HeroBlock.astro
+++ b/src/components/HeroBlock.astro
@@ -4,6 +4,7 @@
 // background image, a content overlay (headline + subheadline), and a
 // call-to-action button. The hero image is the LCP element: it is eager
 // loaded with fetchpriority="high" and width/height attributes.
+import { Picture } from 'astro:assets'
 import ContentBox from './ContentBox.astro'
 import CallToActionButton from './CallToActionButton.astro'
 
@@ -29,12 +30,16 @@ const alt = image?.description || image?.title || ''
 <header class="hero-area">
   {
     image && (
-      <img
+      <Picture
         class="hero-image"
         src={image.src}
         width={image.width}
         height={image.height}
         alt={alt}
+        formats={['avif', 'webp']}
+        sizes="100vw"
+        layout="full-width"
+        loading="eager"
         fetchpriority="high"
       />
     )

--- a/src/components/ProductGroup.astro
+++ b/src/components/ProductGroup.astro
@@ -35,6 +35,7 @@ const alt = photo?.description || photo?.title || ''
         width={photo.width}
         height={photo.height}
         alt={alt}
+        layout="constrained"
         sizes="(min-width: 900px) 38vw, 100vw"
         loading="lazy"
       />

--- a/src/components/ProductGroup.astro
+++ b/src/components/ProductGroup.astro
@@ -2,8 +2,9 @@
 // Native Astro port of src/components/productGroup.jsx.
 // Renders a Produktgruppe tile: a two-column grid (image | text) on
 // large screens with header, description, and examples list. The
-// original used gatsby-image fluid; the Astro port uses a plain <img>
-// with object-fit: cover and the Contentful image dimensions.
+// original used gatsby-image fluid; the Astro port uses an optimized
+// <Image> with object-fit: cover and the Contentful image dimensions.
+import { Image } from 'astro:assets'
 import ContentBox from './ContentBox.astro'
 
 interface Image {
@@ -28,12 +29,13 @@ const alt = photo?.description || photo?.title || ''
 <section class="product-group">
   {
     photo && (
-      <img
+      <Image
         class="product-image"
         src={photo.src}
         width={photo.width}
         height={photo.height}
         alt={alt}
+        sizes="(min-width: 900px) 38vw, 100vw"
         loading="lazy"
       />
     )


### PR DESCRIPTION
## Summary

Replaces the M3 plain `<img>` Contentful-URL rendering with Astro's built-in image service (`astro:assets`). The hero (LCP) uses `<Picture />` with AVIF/WebP format negotiation; below-the-fold employee and product images use `<Image />` with responsive `srcset`. Contentful asset hosts are authorized in `astro.config.mjs` so Astro downloads and transforms remote assets at build time.

This rewrites the branch history: the prior approach (Contentful CDN query-parameter transforms via a hand-rolled `src/lib/contentful-images.ts` helper) is removed entirely. The branch was reset to the M3 baseline `ac71660` and rebuilt on top, so the Contentful-CDN detour does not appear in the commit log.

**Stacked on** PR #4 (M3).

## Strategy

Astro's built-in image service (`astro:assets` `<Image />` and `<Picture />`) — recorded in ADR 05. Chosen over Contentful CDN transforms so the repo is not tied to Contentful for image delivery; switching the CMS later means changing one `image.domains` entry, not a helper module.

Component choice is mixed per-context:
- **Hero (LCP):** `<Picture />` with `formats={['avif','webp']}`, `fetchpriority="high"`, `loading="eager"`, `layout="full-width"` — AVIF/WebP format negotiation via `<picture>`.
- **Employee (below-the-fold):** `<Image />` with `layout="fixed"`, `loading="lazy"` — retina 1x/2x srcset for the fixed 300×182 box.
- **Product (below-the-fold):** `<Image />` with `layout="constrained"`, `sizes="(min-width: 900px) 38vw, 100vw"`, `loading="lazy"` — responsive srcset.

## Changes

- **`astro.config.mjs`**: authorize `images.ctfassets.net` and `videos.ctfassets.net` via `image.domains`.
- **`package.json` / `pnpm-workspace.yaml`**: add `@types/node` to devDependencies (the Contentful loader uses `process.env`); remove legacy `sharp: false` from `allowBuilds` (Gatsby leftover) and add `publicHoistPattern: [sharp]` so Astro's image service can resolve `sharp` at runtime.
- **`HeroBlock.astro`**: replace `<img>` with `<Picture />` from `astro:assets`.
- **`EmployeeTile.astro`**: replace `<img>` with `<Image />`, `layout="fixed"`.
- **`ProductGroup.astro`**: replace `<img>` with `<Image />`, `layout="constrained"`.
- **`scripts/compare-pages.mjs` / `scripts/compare-legal-pages.mjs`**: canonicalize image asset URLs to a sentinel (`<img-src>`/`<img-srcset>`) so parity compares image presence and position, not the specific delivery URL (image URLs are delivery optimization under M4, not content). Collapse `<picture>` wrappers to their `<img>` child. Drop `srcset` from `KEEP_ATTRIBUTES`.
- **`docs/adrs/adr_05_image_strategy.md`** (new): records the Astro image service decision.
- **`docs/superpowers/specs/2026-07-04-astro-migration-design.md`**: M4 decision point, Final stack Images line, and deliberate behavior change entry 5 updated.
- **`docs/superpowers/specs/2026-07-21-m4-astro-image-optimization-design.md`** (new) + **`docs/superpowers/plans/2026-07-21-m4-astro-image-optimization.md`** (new): design and implementation plan.

## Verification

- `pnpm build` PASS — 4 pages, 0 errors
- `pnpm compare:legal` PASS — imprint and data-policy match fixtures
- `pnpm compare:pages` — legal pages PASS; homepage differs only on pre-existing Contentful content drift (TMS certificate date 2024→2027 and product description changes inherited from M3); M4 introduces no new content diffs
- `npm run lint` PASS
- Markup verified: hero `<picture>` with AVIF+WebP `<source>` + `<img fetchpriority="high" loading="eager">`; employee `<img>` with 300w/600w srcset + `loading="lazy"`; product `<img>` with responsive srcset (640w–4242w) + `loading="lazy"`
- No `src/lib/contentful-images.ts` helper exists
- Both old Contentful-CDN commits (`5cf10e3`, `0ea8cfa`) are absent from the branch history

## ADRs

- **ADR 05** added: Image optimization strategy — Astro image service with mixed `<Picture />`/`<Image />` per context.

## Follow-ups (outside M4 scope)

- Homepage `compare:pages` fixture needs re-capturing from the live site to reflect current Contentful content (TMS date + product descriptions). This is a content-management task, not an M4 code change.
- Cookie/storage and manual visual regression checks deferred to the milestone owner (require a browser session).
