### PR TITLE
Astro migration M5: Cloudflare Pages deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,4 @@ Run `lint` before considering work done. The build also runs `astro check` (Type
 
 ## Deploy
 
-To be deployed to Cloudflare Pages (M5). The build output is `dist/` with no SSR adapter — fully static, cookie-free, no service worker.
+Deployed to Cloudflare Pages as a fully static build (`astro build` → `dist/`), no SSR adapter — fully static, cookie-free, no service worker. Build command: `pnpm install --frozen-lockfile && pnpm build`. Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`. Content is fetched from Contentful at build time, so content edits require a rebuild via git push, manual Cloudflare deploy, or a Contentful webhook to a Cloudflare Pages deploy hook.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,23 @@ pnpm compare:pages   # homepage + legal pages against captured fixtures
 
 ## Deploy
 
-Static output in `dist/` is served by Cloudflare Pages (no SSR adapter).
+The site is served by Cloudflare Pages as a fully static build (no SSR adapter).
+
+Cloudflare Pages project settings:
+
+```text
+Framework preset: Astro
+Build command: pnpm install --frozen-lockfile && pnpm build
+Output directory: dist
+Environment variables: CONTENTFUL_SPACE_ID, CONTENTFUL_DELIVERY_TOKEN
+NODE_VERSION: current LTS supported by Astro and Cloudflare Pages
+```
+
+No `CONTENTFUL_PREVIEW_TOKEN` is set for production Cloudflare builds.
+
+### Content rebuilds
+
+Content is fetched from Contentful at build time, so content edits do not
+appear until a rebuild. Trigger a rebuild via git push, a manual Cloudflare
+deploy, or a Contentful webhook pointing at a Cloudflare Pages deploy hook
+(`publish`/`unpublish` events).

--- a/docs/adrs/adr_06_cloudflare_pages.md
+++ b/docs/adrs/adr_06_cloudflare_pages.md
@@ -1,0 +1,42 @@
+# ADR 06: Cloudflare Pages static hosting
+
+## Status
+
+Accepted
+
+## Context
+
+The Astro migration (ADR 01) replaces the Gatsby v2 + Netlify stack. The
+master spec requires a static, cookie-free, service-worker-free deploy with
+no SSR adapter. M5 is the deploy cutover milestone: the Astro static build
+must be served from a host that provisions TLS for `rhode-medizin.de` and
+`www.rhode-medizin.de`, serves `dist/` directly, and supports a content
+rebuild trigger for Contentful-driven updates.
+
+## Decision
+
+Host the Astro static build on Cloudflare Pages.
+
+- No `@astrojs/cloudflare` SSR adapter; the site is fully static
+  (`astro build` → `dist/`).
+- Build command: `pnpm install --frozen-lockfile && pnpm build`.
+- Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`.
+  No preview token in production.
+- `NODE_VERSION` set to current LTS supported by Astro and Cloudflare Pages.
+- Custom domains `rhode-medizin.de` and `www.rhode-medizin.de` attached to
+  the Pages project; Cloudflare provisions the edge certificate.
+- Content rebuilds via git push, manual Cloudflare deploy, or a Contentful
+  webhook to a Cloudflare Pages deploy hook.
+
+Netlify is decommissioned after production verification passes.
+
+## Consequences
+
+- The deploy is fully static, which matches the cookie-free and
+  no-service-worker goals; there is no runtime to set cookies or storage.
+- Cloudflare Pages serves `dist/404.html` automatically with no extra
+  configuration.
+- Content edits in Contentful do not appear until a rebuild; the rebuild
+  path must be triggered explicitly (webhook, git push, or manual deploy).
+- Switching hosts later would require migrating DNS and the deploy
+  pipeline; the static build itself is host-agnostic.

--- a/docs/superpowers/plans/2026-07-08-astro-migration-m5-operator-runbook.md
+++ b/docs/superpowers/plans/2026-07-08-astro-migration-m5-operator-runbook.md
@@ -1,0 +1,228 @@
+# Astro Migration M5 Cloudflare Operator Runbook
+
+> **For the human operator:** This is a manual runbook for the Cloudflare Pages
+> dashboard, DNS, and Netlify decommission steps that cannot be performed from
+> the repository shell. Execute it task-by-task, recording results as you go, then
+> report back so the completion summary can be finalized. Steps use checkbox
+> (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy the static Astro site to Cloudflare Pages, cut DNS over, and
+decommission Netlify after verification.
+
+**Prerequisite:** Task 1 of the M5 plan is complete — deployment docs and ADR 06
+are committed (`324bf0b`). The Astro static build from M4 is verified locally.
+
+**Architecture:** Use Astro's default static output (`astro build` to `dist/`)
+on Cloudflare Pages with no SSR adapter. Keep Netlify live until the Cloudflare
+Pages preview and custom-domain verification gates pass.
+
+**Tech Stack:** Astro static build, Cloudflare Pages, Contentful production
+delivery token, optional Contentful deploy webhook, DNS/custom domains, HTTPS
+verification.
+
+## Global Constraints
+
+- Consumes master spec: `docs/superpowers/specs/2026-07-04-astro-migration-design.md`.
+- Consumes planning design: `docs/superpowers/specs/2026-07-04-astro-migration-planning-design.md`.
+- Depends on completed M4 image optimization and Task 1 deployment docs.
+- M5 goal: site deployed on Cloudflare Pages static, Netlify decommissioned, DNS
+  cut over.
+- No `@astrojs/cloudflare` SSR adapter; the site is fully static.
+- Cloudflare Pages build command: `pnpm install --frozen-lockfile && pnpm build`.
+- Cloudflare Pages output directory: `dist`.
+- Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`.
+- No preview token is needed for production Cloudflare builds.
+- Set `NODE_VERSION` to current LTS supported by Astro and Cloudflare Pages.
+- Keep Netlify alive during verification and remove old Netlify DNS/records only
+  after the new site is confirmed serving correctly.
+- Configure a Contentful webhook to a Cloudflare Pages deploy hook for `publish`
+  and `unpublish`, or document manual rebuilds as the selected alternative.
+- Drop old PWA manifest/service worker behavior.
+- After completion, report results so an ADR/completion summary update can be
+  made if the actual setup differs from what ADR 06 documents.
+
+---
+
+## File Structure
+
+- Modify if actual setup differs: `README.md`.
+- Modify if actual setup differs: `docs/adrs/adr_06_cloudflare_pages.md`.
+- Cloudflare dashboard changes are external and must be recorded in the
+  completion summary.
+
+---
+
+### Task 2: Cloudflare Preview Deployment
+
+**Files:**
+- None expected unless deployment notes are added.
+
+**Interfaces:**
+- Consumes: Cloudflare Pages project and repository settings.
+- Produces: verified `*.pages.dev` preview URL.
+
+- [ ] **Step 1: Create or configure Cloudflare Pages project**
+
+In the Cloudflare dashboard → Workers & Pages → Create → Pages → Connect to
+Git. Select the `rhode-medizin` repository and the production branch
+(`astro-migration-v2-m5` merged into your default branch, or set the production
+branch to the branch you deploy from).
+
+Configure with the settings documented in `README.md` and ADR 06:
+
+```text
+Framework preset: Astro
+Build command: pnpm install --frozen-lockfile && pnpm build
+Output directory: dist
+```
+
+- [ ] **Step 2: Add production environment variables**
+
+In the Pages project → Settings → Environment variables (Production), set:
+
+```text
+CONTENTFUL_SPACE_ID    = <from .env>
+CONTENTFUL_DELIVERY_TOKEN = <from .env>
+NODE_VERSION           = <current LTS, e.g. 20>
+```
+
+Do **not** add `CONTENTFUL_PREVIEW_TOKEN` for production.
+
+- [ ] **Step 3: Run preview deployment**
+
+Trigger a Cloudflare Pages build (Save and Deploy, or Retry deployment). Record
+the `*.pages.dev` URL once the build succeeds:
+
+```text
+Preview URL: https://<project>.pages.dev
+```
+
+- [ ] **Step 4: Verify preview URL**
+
+Open the preview URL and confirm all of the following. Record status for each:
+
+```text
+/                          → 200, homepage renders
+/imprint/                  → 200, legal page renders
+/data-policy/              → 200, legal page renders
+/this-route-does-not-exist → Astro 404 page (not a generic Cloudflare 404)
+HTTPS                      → valid, no browser SSL warning
+Set-Cookie headers         → none
+Cookie banner              → not present
+Service worker             → none registered (DevTools → Application → Service Workers)
+Client-side storage        → none written (DevTools → Application → Local/Session Storage empty)
+```
+
+If any check fails, stop and fix before proceeding to Task 3.
+
+- [ ] **Step 5: Configure content rebuild trigger**
+
+Choose one and record which:
+
+```text
+[ ] Preferred: Created a Cloudflare Pages deploy hook and configured Contentful
+    publish/unpublish webhooks to call it.
+    Deploy hook URL: https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/...
+    Contentful webhook URL: ...
+    Events: publish, unpublish
+
+[ ] Alternative: Documented manual deploy trigger for Contentful updates.
+    Trigger: git push to production branch, or Cloudflare dashboard "Retry deployment".
+```
+
+Expected: content changes have an explicit rebuild path.
+
+---
+
+### Task 3: DNS Cutover And Netlify Decommission
+
+**Files:**
+- Modify if needed: `README.md`.
+- Modify if needed: `docs/adrs/adr_06_cloudflare_pages.md`.
+
+**Interfaces:**
+- Consumes: verified Cloudflare Pages preview deployment (Task 2 Step 4 passed).
+- Produces: production `rhode-medizin.de` and `www.rhode-medizin.de` serving the
+  Astro build over Cloudflare HTTPS.
+
+- [ ] **Step 1: Add custom domains**
+
+In the Pages project → Custom domains → Set up a custom domain. Add both:
+
+```text
+rhode-medizin.de
+www.rhode-medizin.de
+```
+
+Wait for Cloudflare to provision the edge certificate for each (status → Active).
+
+- [ ] **Step 2: Cut DNS over**
+
+Move DNS to Cloudflare, or point current DNS at Cloudflare as appropriate for
+the registrar setup. Do **not** remove old Netlify DNS/records until Cloudflare
+production verification (Step 3) passes.
+
+```text
+DNS action taken: ...
+Old Netlify records still present: yes/no
+```
+
+- [ ] **Step 3: Verify production domains**
+
+Confirm all of the following and record status:
+
+```text
+https://rhode-medizin.de/                  → 200
+https://www.rhode-medizin.de/              → 200
+https://rhode-medizin.de/imprint/          → 200
+https://rhode-medizin.de/data-policy/      → 200
+https://rhode-medizin.de/this-route-does-not-exist → Astro 404 page
+HTTPS certificate                          → valid, no browser SSL warning
+Set-Cookie headers                         → none
+Cookie banner                              → not present
+Service worker                             → none registered
+Client-side storage                        → none written
+```
+
+- [ ] **Step 4: Decommission Netlify**
+
+After production verification passes:
+
+1. Remove old Netlify DNS/records (only after confirming Cloudflare is serving
+   correctly).
+2. Delete the Netlify site.
+
+```text
+Netlify DNS removed: yes/no (date)
+Netlify site deleted: yes/no (date)
+```
+
+- [ ] **Step 5: Update docs if external setup differs**
+
+If the actual DNS/webhook/setup differs from what `README.md` and
+`docs/adrs/adr_06_cloudflare_pages.md` document, update those files and commit:
+
+```bash
+git status --short
+git diff -- README.md docs/adrs/adr_06_cloudflare_pages.md
+git add README.md docs/adrs/adr_06_cloudflare_pages.md
+git commit -m "Record Cloudflare production setup"
+```
+
+Expected: repository docs match the real Cloudflare production setup.
+
+- [ ] **Step 6: Completion summary**
+
+Report back so the M5 completion summary can be finalized. Include:
+
+```text
+Cloudflare preview URL: ...
+Production URLs: https://rhode-medizin.de, https://www.rhode-medizin.de
+Route/status verification: / 200, /imprint/ 200, /data-policy/ 200, 404 page works
+HTTPS result: valid, no SSL warning
+Cookie/storage/service-worker result: none
+Contentful rebuild trigger choice: webhook / manual
+Netlify decommission result: DNS removed, site deleted
+ADR status: adr_06_cloudflare_pages.md added (and updated if setup differed)
+Commit hashes: 324bf0b (docs), <this commit if docs updated>
+```

--- a/docs/superpowers/specs/2026-07-08-stale-homepage-fixture-design.md
+++ b/docs/superpowers/specs/2026-07-08-stale-homepage-fixture-design.md
@@ -1,0 +1,88 @@
+# Stale Homepage Parity Fixture Design
+
+The homepage parity check (`pnpm compare:pages`) fails because the captured
+live fixture at `tests/fixtures/live/index.html` is stale relative to current
+Contentful content. The legal page fixtures (`imprint`, `data-policy`) still
+pass. This spec covers re-capturing the homepage fixture so parity checks are
+green again.
+
+## Problem
+
+`pnpm compare:pages` compares the Astro build's normalized `<article>` content
+against captured Gatsby live fixtures in `tests/fixtures/live/`. Two content
+drifts were identified during M5 verification (systematic debugging, root cause
+confirmed pre-existing at M4 commit `0ea8cfa`):
+
+1. **Certificate expiry date.** The fixture records `Gültig bis → 09.Dezember
+   2024`; Contentful now returns `09.Dezember 2027` (certificate was renewed).
+2. **Services section restructure.** The fixture has a prose paragraph
+   ("Als Vertragspartner der Fa. Aesculap stellen wir ein vielfältiges
+   Leistungsspe…"); Contentful now returns a `<ul>` of instruments (Scheren,
+   Pinzetten, Klemmen, Nadelhalter, Skalpelle, …).
+
+Both are Contentful content changes, not code regressions. The Astro build
+correctly renders current Contentful content.
+
+## Constraint
+
+The live Gatsby site is still hosted on Netlify and is the source for fixture
+re-capture. It has a known TLS certificate issue, so the capture tool must
+disable certificate verification (e.g. `curl -k`). The live site was not
+reachable from the sandbox where M5 was executed (DNS only resolved IPv6
+Netlify records; IPv4 attempts returned HTTP 429 from the Netlify edge), so the
+capture must be performed from a machine with working access to the live site.
+
+The fixture must reflect the **same Contentful content state** the Astro build
+renders. Capture the fixture immediately after a successful `pnpm build` (which
+fetches current Contentful content) so the fixture and build are aligned.
+
+## Decision
+
+Re-capture only the homepage fixture (`tests/fixtures/live/index.html`). The
+legal page fixtures are current and must not be touched.
+
+Capture process:
+
+1. Run `pnpm build` to confirm the Astro build fetches current Contentful
+   content successfully.
+2. Fetch the live Gatsby homepage HTML, disabling TLS verification:
+
+   ```sh
+   curl -k -o tests/fixtures/live/index.html https://rhode-medizin.de/
+   ```
+
+   If the apex redirects to `www.`, follow it. The captured file is the raw
+   Gatsby HTML — the parity script's `extractMainContent` normalizes Gatsby
+   noise (scripts, gatsby-image wrappers, styled-components classes) at
+   comparison time.
+3. Run `pnpm compare:pages` and confirm all three pages pass.
+
+If the live site is still returning 429 or is otherwise unreachable, the
+capture must wait until access is available. Do not fabricate a fixture from
+the Astro build — that would defeat the parity check's purpose.
+
+## Scope
+
+- `tests/fixtures/live/index.html` only.
+- No source code changes.
+- No changes to `scripts/compare-pages.mjs` — the normalization logic is
+  correct; only the fixture data is stale.
+
+## Verification
+
+```sh
+pnpm build
+pnpm compare:pages
+```
+
+Expected: all three pages pass (`imprint`, `data-policy`, `homepage`).
+
+## Out of Scope
+
+- Adding a fixture capture script. The existing manual capture process is
+  sufficient; this is a one-time refresh.
+- Migrating fixtures to a different capture source (e.g. Contentful API
+  snapshots). The live Gatsby site remains the parity reference until Netlify
+  is decommissioned in M5 Task 3.
+- Fixing the live site's TLS certificate. That is a Netlify/DNS concern handled
+  in the M5 Cloudflare cutover.


### PR DESCRIPTION
Milestone 5 of the Astro migration: deploy documentation, Cloudflare Pages ADR, and operator runbook for the manual cutover steps.

## What's included

- **Cloudflare Pages deployment docs** (`324bf0b`) — `README.md` documents the Pages project settings (preset, build command, output dir, env vars, NODE_VERSION) and the content rebuild trigger path. `AGENTS.md` deploy section updated from future tense to present tense. Added `docs/adrs/adr_06_cloudflare_pages.md` for the static hosting decision.
- **Operator runbook** (`a1e078e`) — `docs/superpowers/plans/2026-07-08-astro-migration-m5-operator-runbook.md` for the manual Cloudflare/DNS/Netlify steps (Tasks 2 & 3) that require dashboard access.
- **Stale homepage fixture spec** (`f03a56e`) — documents the pre-existing homepage parity failure (Contentful content drift, not a code regression) and the re-capture process. To be tackled separately.

## Out of scope for this PR

- **Cloudflare preview deployment** (Task 2) and **DNS cutover + Netlify decommission** (Task 3) require Cloudflare dashboard, DNS registrar, and Netlify access. These are captured in the operator runbook for manual execution.
- **Homepage fixture re-capture** — tracked in the new spec; the live site's TLS cert issue and Netlify 429 rate-limiting prevented capture during this session.

## Verification

- `pnpm lint` — passed
- `pnpm build` — passed (0 errors, 0 warnings, 0 hints; 4 pages built)
- `pnpm compare:legal` — passed (imprint, data-policy)
- `pnpm compare:pages` — legal pages pass; homepage fails due to stale fixture (pre-existing, documented in spec)

Stacked on top of #5 (M4).