### PR TITLE
Switch production hosting to Netlify (Cloudflare Pages fallback)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,6 @@ Run `lint` before considering work done. The build also runs `astro check` (Type
 
 ## Deploy
 
-To be deployed to Cloudflare Pages (M5). The build output is `dist/` with no SSR adapter — fully static, cookie-free, no service worker.
+Deployed to Netlify as a fully static build (`astro build` → `dist/`), no SSR adapter — fully static, cookie-free, no service worker. Build config is committed in `netlify.toml` at the repo root; build command `pnpm install --frozen-lockfile && pnpm build`, publish dir `dist`, `NODE_VERSION = "22"`. Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN` (set in the Netlify dashboard, not committed). DNS stays at the registrar: apex `rhode-medizin.de` ALIAS/ANAME → `apex-loadbalancer.netlify.com`, `www.rhode-medizin.de` CNAME → `<site-slug>.netlify.app`; Netlify provisions TLS via DCV. Content is fetched from Contentful at build time, so content edits require a rebuild via git push, manual Netlify deploy, or a Contentful webhook to a Netlify build hook (`publish`/`unpublish` on Entry and Asset).
+
+The Cloudflare Pages project stays configured and builds on every git push as a dormant fallback; its `*.pages.dev` URL remains functional. To switch traffic to Cloudflare, repoint DNS and let Cloudflare provision the apex cert. See `docs/adrs/adr_07_netlify.md` (decision) and `docs/adrs/adr_06_cloudflare_pages.md` (Cloudflare setup, superseded).

--- a/README.md
+++ b/README.md
@@ -52,4 +52,42 @@ pnpm compare:pages   # homepage + legal pages against captured fixtures
 
 ## Deploy
 
-Static output in `dist/` is served by Cloudflare Pages (no SSR adapter).
+The site is served by Netlify as a fully static build (no SSR adapter). The
+build config is committed in `netlify.toml`:
+
+```toml
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"
+```
+
+Production env vars (set in the Netlify dashboard, not committed):
+`CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`. No
+`CONTENTFUL_PREVIEW_TOKEN` is set for production builds.
+
+### DNS and TLS
+
+DNS stays at the current registrar. Netlify provisions the TLS certificate
+via DCV:
+
+- Apex `rhode-medizin.de`: ALIAS/ANAME → `apex-loadbalancer.netlify.com`
+- `www.rhode-medizin.de`: CNAME → `<site-slug>.netlify.app`
+
+### Content rebuilds
+
+Content is fetched from Contentful at build time, so content edits do not
+appear until a rebuild. Trigger a rebuild via git push, a manual Netlify
+deploy, or a Contentful webhook pointing at a Netlify build hook
+(`publish`/`unpublish` events on Entry and Asset).
+
+### Cloudflare Pages fallback
+
+The Cloudflare Pages project stays configured and builds on every git push
+with the same build command and env vars. Its `*.pages.dev` URL remains
+functional as an emergency fallback. To switch traffic to Cloudflare,
+repoint DNS and let Cloudflare provision the apex cert. See
+`docs/adrs/adr_06_cloudflare_pages.md` and
+`docs/adrs/adr_07_netlify.md`.

--- a/docs/adrs/adr_06_cloudflare_pages.md
+++ b/docs/adrs/adr_06_cloudflare_pages.md
@@ -15,6 +15,9 @@ must be served from a host that provisions TLS for `rhode-medizin.de` and
 `www.rhode-medizin.de`, serves `dist/` directly, and supports a content
 rebuild trigger for Contentful-driven updates.
 
+Superseded for production traffic by ADR 07 (Netlify), which avoids
+transferring DNS off the registrar.
+
 ## Decision
 
 Host the Astro static build on Cloudflare Pages.

--- a/docs/adrs/adr_06_cloudflare_pages.md
+++ b/docs/adrs/adr_06_cloudflare_pages.md
@@ -1,0 +1,44 @@
+# ADR 06: Cloudflare Pages static hosting
+
+## Status
+
+Superseded by `docs/adrs/adr_07_netlify.md` for the production-traffic
+decision. This ADR is retained as the historical record of the Cloudflare
+Pages setup, which remains configured as a dormant fallback.
+
+## Context
+
+The Astro migration (ADR 01) replaces the Gatsby v2 + Netlify stack. The
+master spec requires a static, cookie-free, service-worker-free deploy with
+no SSR adapter. M5 is the deploy cutover milestone: the Astro static build
+must be served from a host that provisions TLS for `rhode-medizin.de` and
+`www.rhode-medizin.de`, serves `dist/` directly, and supports a content
+rebuild trigger for Contentful-driven updates.
+
+## Decision
+
+Host the Astro static build on Cloudflare Pages.
+
+- No `@astrojs/cloudflare` SSR adapter; the site is fully static
+  (`astro build` → `dist/`).
+- Build command: `pnpm install --frozen-lockfile && pnpm build`.
+- Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`.
+  No preview token in production.
+- `NODE_VERSION` set to current LTS supported by Astro and Cloudflare Pages.
+- Custom domains `rhode-medizin.de` and `www.rhode-medizin.de` attached to
+  the Pages project; Cloudflare provisions the edge certificate.
+- Content rebuilds via git push, manual Cloudflare deploy, or a Contentful
+  webhook to a Cloudflare Pages deploy hook.
+
+Netlify is decommissioned after production verification passes.
+
+## Consequences
+
+- The deploy is fully static, which matches the cookie-free and
+  no-service-worker goals; there is no runtime to set cookies or storage.
+- Cloudflare Pages serves `dist/404.html` automatically with no extra
+  configuration.
+- Content edits in Contentful do not appear until a rebuild; the rebuild
+  path must be triggered explicitly (webhook, git push, or manual deploy).
+- Switching hosts later would require migrating DNS and the deploy
+  pipeline; the static build itself is host-agnostic.

--- a/docs/adrs/adr_07_netlify.md
+++ b/docs/adrs/adr_07_netlify.md
@@ -1,0 +1,61 @@
+# ADR 07: Netlify primary hosting (Cloudflare Pages fallback)
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 06 chose Cloudflare Pages as the production host. Cloudflare requires
+moving DNS management fully to Cloudflare in order to provision an apex TLS
+certificate. The project prefers to keep DNS at the current registrar.
+
+Netlify permits the apex domain to remain at the existing registrar and
+provisions its certificate via DCV using an ALIAS/ANAME record at the apex
+and a CNAME for `www`. Keeping DNS at the registrar is preferable, so
+Netlify becomes the primary host.
+
+The Astro static build (`astro build` → `dist/`) is host-agnostic and
+requires no code or build changes; only hosting and DNS configuration
+change. The legacy `requirements.txt` was for `subfont` only and is not
+reintroduced (ADR 04 handles fonts).
+
+## Decision
+
+Host the production Astro static build on Netlify. Keep the existing
+Cloudflare Pages project configured and building on every git push as a
+dormant fallback.
+
+- No `@astrojs/netlify` SSR adapter; the site is fully static.
+- Build config committed to the repo as `netlify.toml`:
+  `pnpm install --frozen-lockfile && pnpm build`, publish `dist`,
+  `NODE_VERSION = "22"`.
+- Production env vars `CONTENTFUL_SPACE_ID` and
+  `CONTENTFUL_DELIVERY_TOKEN` are set in the Netlify dashboard, not
+  committed. No preview token in production.
+- DNS at the registrar: apex `rhode-medizin.de` ALIAS/ANAME →
+  `apex-loadbalancer.netlify.com`; `www.rhode-medizin.de` CNAME →
+  `<site-slug>.netlify.app`. Netlify provisions the TLS certificate via
+  DCV.
+- Content rebuilds via git push, manual Netlify deploy, or a Contentful
+  webhook to a Netlify build hook (`publish`/`unpublish` on Entry and
+  Asset).
+- Cloudflare Pages fallback: the `*.pages.dev` URL stays functional; to
+  switch traffic to Cloudflare, repoint DNS and let Cloudflare provision
+  the apex cert.
+
+## Consequences
+
+- DNS stays at the registrar; Netlify manages TLS via DCV. This is the
+  primary motivation for the switch.
+- The deploy is fully static and host-agnostic; the same `dist/` runs on
+  Netlify or Cloudflare Pages with no code change.
+- `dist/404.html` is served automatically by Netlify.
+- Content edits in Contentful do not appear until a rebuild; the
+  Contentful → Netlify build webhook triggers that rebuild automatically.
+- Cloudflare Pages remains configured as a fallback but is not actively
+  verified against the real domain; if it is ever needed, run a fresh
+  build and parity check before repointing DNS.
+- ADR 06 is superseded for the production-traffic decision only; it is
+  retained as a historical record of the Cloudflare setup and fallback
+  config.

--- a/docs/superpowers/plans/2026-07-23-netlify-primary-hosting.md
+++ b/docs/superpowers/plans/2026-07-23-netlify-primary-hosting.md
@@ -1,0 +1,431 @@
+# Netlify Primary Hosting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch production traffic for `rhode-medizin.de` from Cloudflare Pages to Netlify by adding a committed `netlify.toml`, updating docs/ADRs, and providing an operator runbook for the dashboard/DNS/webhook steps that cannot be performed from the repo shell.
+
+**Architecture:** The Astro static build (`astro build` → `dist/`) is host-agnostic and requires no code changes. Repo-side work (Tasks 1–3) adds `netlify.toml`, ADR 07 supersedes ADR 06, and README/AGENTS.md are updated. Operator-side work (Task 4) covers Netlify site setup, env vars, custom domains, DNS records at the registrar, TLS verification, and the Contentful → Netlify build webhook — none of which can be committed. Cloudflare Pages stays configured as a dormant fallback.
+
+**Tech Stack:** Astro static build, Netlify (build via `netlify.toml`, hosting, build hooks), Contentful (webhook), DNS registrar (ALIAS/ANAME + CNAME), Cloudflare Pages (fallback).
+
+## Global Constraints
+
+- Consumes master spec: `docs/superpowers/specs/2026-07-23-netlify-primary-hosting-design.md`.
+- No SSR adapter; the site is fully static (`astro build` → `dist/`).
+- Netlify build command: `pnpm install --frozen-lockfile && pnpm build`.
+- Netlify publish directory: `dist`.
+- Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN` (set in the Netlify dashboard, not committed).
+- No `CONTENTFUL_PREVIEW_TOKEN` for production builds.
+- Set `NODE_VERSION` to current LTS (22) supported by Astro and Netlify.
+- No `requirements.txt`; the legacy file was for `subfont` only and is not reintroduced.
+- No custom `[[redirects]]` or `[[headers]]` in `netlify.toml`; platform defaults are sufficient.
+- ADR numbering is append-only (Approach A): existing `adr_05_*` and `adr_06_*` filename collisions are left in place; the new ADR is `adr_07_netlify.md`.
+- Run `pnpm lint` before considering repo-side work done (AGENTS.md).
+- Cloudflare Pages project is NOT deleted; it keeps building on git push as a dormant fallback.
+- DNS stays at the current registrar (the motivation for this whole change); no transfer to Netlify DNS or Cloudflare DNS.
+
+---
+
+## File Structure
+
+- Create: `netlify.toml` (repo root) — Netlify build config; single source of truth for build command, publish dir, NODE_VERSION.
+- Create: `docs/adrs/adr_07_netlify.md` — Supersedes ADR 06 for production traffic; records motivation (DNS), decision (Netlify primary + Cloudflare fallback), build config, DNS records, and Contentful webhook.
+- Modify: `docs/adrs/adr_06_cloudflare_pages.md` — Status changed to `Superseded by adr_07_netlify.md`; one-line note in Context pointing to ADR 07. Body left intact as historical record.
+- Modify: `README.md` — Deploy section rewritten: Netlify primary with `netlify.toml` reference, env vars, DNS records, Contentful webhook; short "Cloudflare Pages fallback" subsection.
+- Modify: `AGENTS.md` — Deploy section updated: Netlify primary + Cloudflare fallback; build command and env-var names same on both platforms; reference `netlify.toml`.
+- Operator-only (no file changes, recorded in completion summary): Netlify dashboard (site, env vars, custom domains, build hook), registrar DNS records, Contentful webhook.
+
+---
+
+### Task 1: Add `netlify.toml`
+
+**Files:**
+- Create: `netlify.toml`
+
+**Interfaces:**
+- Consumes: build command `pnpm install --frozen-lockfile && pnpm build` and publish dir `dist` from the spec and from `docs/adrs/adr_06_cloudflare_pages.md`.
+- Produces: a committed `netlify.toml` at repo root that Netlify auto-detects on the next build. Tasks 2 and 3 reference the same build command and env-var names.
+
+- [ ] **Step 1: Create `netlify.toml` at repo root**
+
+```
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"
+```
+
+Notes for the implementer:
+- No `[[redirects]]` or `[[headers]]` block. Astro emits `dist/404.html`, which Netlify serves automatically. Platform defaults are acceptable per the spec.
+- Do NOT add `CONTENTFUL_SPACE_ID` or `CONTENTFUL_DELIVERY_TOKEN` here — they are secrets and stay in the Netlify dashboard, matching the Cloudflare convention documented in `docs/adrs/adr_06_cloudflare_pages.md`.
+- Do NOT reintroduce `requirements.txt`. The legacy file was for `subfont` (fonttools/brotli/zopfli), which is gone; Astro handles fonts per ADR 04 (`docs/adrs/adr_04_fonts.md`). No Python runtime is needed.
+- `NODE_VERSION = "22"` matches current LTS supported by Astro and Netlify.
+
+- [ ] **Step 2: Verify `netlify.toml` parses and the build still succeeds locally**
+
+Run: `pnpm lint`
+Expected: PASS (Prettier checks `**/*.{js,ts,astro,json,md,yml,css}`; TOML is not in the lint glob, so this only confirms no other files were touched.)
+
+Run: `pnpm build`
+Expected: `astro check` passes and `astro build` writes `dist/`. `netlify.toml` does not affect the local Astro build.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add netlify.toml
+git commit -m "Add netlify.toml for Netlify build config" -m "Mirrors the Cloudflare build command and publish dir so the same static Astro build can be served from either host. Secrets stay in the dashboard."
+```
+
+---
+
+### Task 2: Add ADR 07 and mark ADR 06 superseded
+
+**Files:**
+- Create: `docs/adrs/adr_07_netlify.md`
+- Modify: `docs/adrs/adr_06_cloudflare_pages.md`
+
+**Interfaces:**
+- Consumes: motivation (DNS), decision (Netlify primary + Cloudflare fallback), build config, DNS records, and Contentful webhook from the spec.
+- Produces: `docs/adrs/adr_07_netlify.md` as the authoritative decision record for production hosting. Task 3's README/AGENTS.md updates reference both ADR 07 and ADR 06 by filename.
+
+- [ ] **Step 1: Create `docs/adrs/adr_07_netlify.md`**
+
+```
+# ADR 07: Netlify primary hosting (Cloudflare Pages fallback)
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 06 chose Cloudflare Pages as the production host. Cloudflare requires
+moving DNS management fully to Cloudflare in order to provision an apex TLS
+certificate. The project prefers to keep DNS at the current registrar.
+
+Netlify permits the apex domain to remain at the existing registrar and
+provisions its certificate via DCV using an ALIAS/ANAME record at the apex
+and a CNAME for `www`. Keeping DNS at the registrar is preferable, so
+Netlify becomes the primary host.
+
+The Astro static build (`astro build` → `dist/`) is host-agnostic and
+requires no code or build changes; only hosting and DNS configuration
+change. The legacy `requirements.txt` was for `subfont` only and is not
+reintroduced (ADR 04 handles fonts).
+
+## Decision
+
+Host the production Astro static build on Netlify. Keep the existing
+Cloudflare Pages project configured and building on every git push as a
+dormant fallback.
+
+- No `@astrojs/netlify` SSR adapter; the site is fully static.
+- Build config committed to the repo as `netlify.toml`:
+  `pnpm install --frozen-lockfile && pnpm build`, publish `dist`,
+  `NODE_VERSION = "22"`.
+- Production env vars `CONTENTFUL_SPACE_ID` and
+  `CONTENTFUL_DELIVERY_TOKEN` are set in the Netlify dashboard, not
+  committed. No preview token in production.
+- DNS at the registrar: apex `rhode-medizin.de` ALIAS/ANAME →
+  `apex-loadbalancer.netlify.com`; `www.rhode-medizin.de` CNAME →
+  `<site-slug>.netlify.app`. Netlify provisions the TLS certificate via
+  DCV.
+- Content rebuilds via git push, manual Netlify deploy, or a Contentful
+  webhook to a Netlify build hook (`publish`/`unpublish` on Entry and
+  Asset).
+- Cloudflare Pages fallback: the `*.pages.dev` URL stays functional; to
+  switch traffic to Cloudflare, repoint DNS and let Cloudflare provision
+  the apex cert.
+
+## Consequences
+
+- DNS stays at the registrar; Netlify manages TLS via DCV. This is the
+  primary motivation for the switch.
+- The deploy is fully static and host-agnostic; the same `dist/` runs on
+  Netlify or Cloudflare Pages with no code change.
+- `dist/404.html` is served automatically by Netlify.
+- Content edits in Contentful do not appear until a rebuild; the
+  Contentful → Netlify build webhook triggers that rebuild automatically.
+- Cloudflare Pages remains configured as a fallback but is not actively
+  verified against the real domain; if it is ever needed, run a fresh
+  build and parity check before repointing DNS.
+- ADR 06 is superseded for the production-traffic decision only; it is
+  retained as a historical record of the Cloudflare setup and fallback
+  config.
+```
+
+- [ ] **Step 2: Mark `docs/adrs/adr_06_cloudflare_pages.md` as Superseded**
+
+Change the `## Status` section from:
+
+```
+## Status
+
+Accepted
+```
+
+to:
+
+```
+## Status
+
+Superseded by `docs/adrs/adr_07_netlify.md` for the production-traffic
+decision. This ADR is retained as the historical record of the Cloudflare
+Pages setup, which remains configured as a dormant fallback.
+```
+
+Do NOT modify the rest of the file. The Decision and Consequences sections
+stay intact as the historical record referenced by the Cloudflare Pages
+fallback path.
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `pnpm lint`
+Expected: PASS (Markdown files are in the Prettier glob.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adrs/adr_07_netlify.md docs/adrs/adr_06_cloudflare_pages.md
+git commit -m "Add ADR 07 Netlify primary, supersede ADR 06" -m "Netlify permits ALIAS/ANAME at the existing registrar for apex TLS, while Cloudflare requires moving DNS to Cloudflare. Cloudflare Pages stays configured as a dormant fallback."
+```
+
+---
+
+### Task 3: Update README and AGENTS.md Deploy sections
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+
+**Interfaces:**
+- Consumes: `netlify.toml` from Task 1 and ADR 07/06 from Task 2.
+- Produces: README and AGENTS.md Deploy sections that describe Netlify as primary with Cloudflare Pages as fallback, referencing the committed `netlify.toml` and both ADRs.
+
+- [ ] **Step 1: Replace the Deploy section in `README.md`**
+
+The current Deploy section (lines 53–74 of `README.md`) reads:
+
+```
+## Deploy
+
+The site is served by Cloudflare Pages as a fully static build (no SSR adapter).
+
+Cloudflare Pages project settings:
+
+```text
+Framework preset: Astro
+Build command: pnpm install --frozen-lockfile && pnpm build
+Output directory: dist
+Environment variables: CONTENTFUL_SPACE_ID, CONTENTFUL_DELIVERY_TOKEN
+NODE_VERSION: current LTS supported by Astro and Cloudflare Pages
+```
+
+No `CONTENTFUL_PREVIEW_TOKEN` is set for production Cloudflare builds.
+
+### Content rebuilds
+
+Content is fetched from Contentful at build time, so content edits do not
+appear until a rebuild. Trigger a rebuild via git push, a manual Cloudflare
+deploy, or a Contentful webhook pointing at a Cloudflare Pages deploy hook
+(`publish`/`unpublish` events).
+```
+
+Replace that entire block with:
+
+```
+## Deploy
+
+The site is served by Netlify as a fully static build (no SSR adapter). The
+build config is committed in `netlify.toml`:
+
+```toml
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"
+```
+
+Production env vars (set in the Netlify dashboard, not committed):
+`CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`. No
+`CONTENTFUL_PREVIEW_TOKEN` is set for production builds.
+
+### DNS and TLS
+
+DNS stays at the current registrar. Netlify provisions the TLS certificate
+via DCV:
+
+- Apex `rhode-medizin.de`: ALIAS/ANAME → `apex-loadbalancer.netlify.com`
+- `www.rhode-medizin.de`: CNAME → `<site-slug>.netlify.app`
+
+### Content rebuilds
+
+Content is fetched from Contentful at build time, so content edits do not
+appear until a rebuild. Trigger a rebuild via git push, a manual Netlify
+deploy, or a Contentful webhook pointing at a Netlify build hook
+(`publish`/`unpublish` events on Entry and Asset).
+
+### Cloudflare Pages fallback
+
+The Cloudflare Pages project stays configured and builds on every git push
+with the same build command and env vars. Its `*.pages.dev` URL remains
+functional as an emergency fallback. To switch traffic to Cloudflare,
+repoint DNS and let Cloudflare provision the apex cert. See
+`docs/adrs/adr_06_cloudflare_pages.md` and
+`docs/adrs/adr_07_netlify.md`.
+```
+
+- [ ] **Step 2: Update the Deploy section in `AGENTS.md`**
+
+The current Deploy section in `AGENTS.md` reads:
+
+```
+## Deploy
+
+Deployed to Cloudflare Pages as a fully static build (`astro build` → `dist/`), no SSR adapter — fully static, cookie-free, no service worker. Build command: `pnpm install --frozen-lockfile && pnpm build`. Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`. Content is fetched from Contentful at build time, so content edits require a rebuild via git push, manual Cloudflare deploy, or a Contentful webhook to a Cloudflare Pages deploy hook.
+```
+
+Replace it with:
+
+```
+## Deploy
+
+Deployed to Netlify as a fully static build (`astro build` → `dist/`), no SSR adapter — fully static, cookie-free, no service worker. Build config is committed in `netlify.toml` at the repo root; build command `pnpm install --frozen-lockfile && pnpm build`, publish dir `dist`, `NODE_VERSION = "22"`. Production env vars: `CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN` (set in the Netlify dashboard, not committed). DNS stays at the registrar: apex `rhode-medizin.de` ALIAS/ANAME → `apex-loadbalancer.netlify.com`, `www.rhode-medizin.de` CNAME → `<site-slug>.netlify.app`; Netlify provisions TLS via DCV. Content is fetched from Contentful at build time, so content edits require a rebuild via git push, manual Netlify deploy, or a Contentful webhook to a Netlify build hook (`publish`/`unpublish` on Entry and Asset).
+
+The Cloudflare Pages project stays configured and builds on every git push as a dormant fallback; its `*.pages.dev` URL remains functional. To switch traffic to Cloudflare, repoint DNS and let Cloudflare provision the apex cert. See `docs/adrs/adr_07_netlify.md` (decision) and `docs/adrs/adr_06_cloudflare_pages.md` (Cloudflare setup, superseded).
+```
+
+- [ ] **Step 3: Verify lint passes**
+
+Run: `pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md AGENTS.md
+git commit -m "Document Netlify primary deploy with Cloudflare fallback" -m "README and AGENTS.md Deploy sections now describe Netlify primary (netlify.toml, ALIAS/ANAME at registrar, Contentful -> Netlify webhook) with Cloudflare Pages as a dormant fallback."
+```
+
+---
+
+### Task 4: Operator runbook — Netlify site setup, DNS, and Contentful webhook
+
+> **For the human operator:** This is a manual runbook for the Netlify dashboard, the DNS registrar, and the Contentful webhook settings. None of these steps can be performed from the repo shell. Execute them in order, recording results as you go, then report back so the completion summary can be finalized. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Prerequisite:** Tasks 1–3 are committed and pushed; `netlify.toml` is on the default branch.
+
+**Files:**
+- None. All changes are external to the repo and must be recorded in the completion summary.
+
+**Interfaces:**
+- Consumes: `netlify.toml` from Task 1; ADR 07 from Task 2; README/AGENTS.md from Task 3.
+- Produces: a live Netlify production site at `https://rhode-medizin.de` and `https://www.rhode-medizin.de`, a Contentful → Netlify build webhook, and a still-functional Cloudflare Pages fallback at its `*.pages.dev` URL.
+
+- [ ] **Step 1: Connect the repo to Netlify and confirm the build picks up `netlify.toml`**
+
+In Netlify:
+1. Create a new site from Git → connect the `maeh2k/rhode-medizin` repository.
+2. Set the production branch to the default branch.
+3. Confirm Netlify detects `netlify.toml` and shows build command
+   `pnpm install --frozen-lockfile && pnpm build`, publish dir `dist`,
+   `NODE_VERSION = "22"`. Do not override these in the dashboard.
+4. Trigger the first build and confirm it succeeds with a green deploy.
+
+- [ ] **Step 2: Set production env vars in the Netlify dashboard**
+
+In Netlify → Site settings → Environment variables, add:
+- `CONTENTFUL_SPACE_ID` = the production Contentful space ID (same value as Cloudflare Pages).
+- `CONTENTFUL_DELIVERY_TOKEN` = the production Contentful delivery token (same value as Cloudflare Pages).
+
+Do NOT set `CONTENTFUL_PREVIEW_TOKEN` or `CONTENTFUL_USE_PREVIEW` for production.
+
+Trigger a new build and confirm it succeeds (env vars are present at build time).
+
+- [ ] **Step 3: Add custom domains in Netlify**
+
+In Netlify → Site settings → Domain management → Domains:
+1. Add custom domain `rhode-medizin.de`.
+2. Add custom domain `www.rhode-medizin.de`.
+3. Set `www.rhode-medizin.de` as the primary domain (or apex, per preference); Netlify will set up a redirect from the secondary to the primary if configured.
+
+- [ ] **Step 4: Point DNS at the registrar**
+
+At the current DNS registrar, set:
+- Apex `rhode-medizin.de`: ALIAS/ANAME → `apex-loadbalancer.netlify.com`.
+- `www.rhode-medizin.de`: CNAME → `<site-slug>.netlify.app` (use the exact subdomain Netlify shows in the dashboard).
+
+Do NOT transfer DNS to Netlify DNS or Cloudflare DNS — keeping DNS at the registrar is the motivation for this change.
+
+- [ ] **Step 5: Wait for TLS provisioning and verify**
+
+1. In Netlify → Site settings → Domain management → HTTPS, wait for "Certificate verified" (typically minutes).
+2. Visit `https://rhode-medizin.de` and `https://www.rhode-medizin.de`; confirm the Astro site loads and the TLS cert is issued by Netlify.
+3. Visit an unknown path (e.g. `https://rhode-medizin.de/this-does-not-exist`) and confirm `dist/404.html` is served (status 404, not a Netlify-branded error page).
+
+- [ ] **Step 6: Create a Netlify build hook**
+
+In Netlify → Site settings → Build & deploy → Continuous deployment → Build hooks:
+1. Create a build hook named `contentful-content-published`.
+2. Copy the generated hook URL.
+
+- [ ] **Step 7: Configure the Contentful webhook**
+
+In Contentful → Settings → Webhooks:
+1. Create a webhook with URL = the Netlify build hook URL from Step 6.
+2. Triggers: `publish` and `unpublish` on Entry and Asset.
+3. Filters: target this space only.
+4. Save.
+
+- [ ] **Step 8: Verify the Contentful → Netlify webhook fires**
+
+1. In Contentful, publish a trivial content edit (or unpublish + republish an existing entry).
+2. In Netlify → Deploys, confirm a new deploy appears with "Triggered by webhook" in the deploy log.
+3. If no deploy appears, check Contentful → Settings → Webhooks → delivery history for the failed delivery and retry.
+
+- [ ] **Step 9: Confirm the Cloudflare Pages fallback still works**
+
+1. Push a trivial commit (or trigger a manual Cloudflare deploy) and confirm the Cloudflare Pages build succeeds.
+2. Visit the Cloudflare Pages `*.pages.dev` URL and confirm the site loads. This is the dormant fallback; it is not attached to the production domain.
+
+- [ ] **Step 10: Report results**
+
+Record in the completion summary:
+- Netlify site URL and the `*.netlify.app` subdomain used for the `www` CNAME.
+- Confirmation that `netlify.toml` was picked up unmodified.
+- Confirmation that env vars were set (names only — never values).
+- The DNS records set at the registrar (ALIAS/ANAME apex + CNAME www).
+- Confirmation that TLS is verified for both apex and `www`.
+- Confirmation that `dist/404.html` is served for unknown paths.
+- Confirmation that the Contentful webhook fires a Netlify build.
+- Confirmation that the Cloudflare Pages fallback build still succeeds and the `*.pages.dev` URL serves the site.
+- Any deviations from ADR 07 / this plan, so `docs/adrs/adr_07_netlify.md` can be amended if needed.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+- `netlify.toml` with build command, publish, NODE_VERSION, no headers/redirects → Task 1.
+- Secrets in dashboard, not committed → Task 1 (note) + Task 4 Step 2.
+- No `requirements.txt` reintroduction → Task 1 (note).
+- DNS records (ALIAS apex + CNAME www), TLS via DCV, no DNS transfer → Task 4 Steps 3–5.
+- Cloudflare Pages fallback stays configured and building → Task 4 Step 9; documented in README/AGENTS.md (Task 3) and ADR 07 (Task 2).
+- Contentful → Netlify build webhook (`publish`/`unpublish` on Entry and Asset) → Task 4 Steps 6–8.
+- New ADR 07 with motivation, decision, build config, DNS, webhook → Task 2 Step 1.
+- ADR 06 marked Superseded, body intact → Task 2 Step 2.
+- README Deploy section rewritten (Netlify primary + Cloudflare fallback subsection) → Task 3 Step 1.
+- AGENTS.md Deploy section updated → Task 3 Step 2.
+- ADR numbering append-only (Approach A); no renumbering → Global Constraints + Task 2 (filename `adr_07_netlify.md`).
+- `pnpm lint` before completion → Tasks 1–3 verification steps.
+- No code changes to `astro.config.mjs`, `package.json`, or source → confirmed; no such files appear in any task.
+- Rollout ordering (build config → site setup → env vars → custom domains → DNS → TLS → webhook → docs) → Task order 1→2→3 (repo) then 4 (operator); operator runbook follows the spec's Rollout section.
+
+**2. Placeholder scan:** No TBD/TODO. Every step shows exact content (the `netlify.toml` block, the ADR 07 body, the ADR 06 status replacement, the README/AGENTS.md before/after blocks, the operator dashboard paths and DNS records). `<site-slug>` is intentionally a placeholder for a value that only exists after the Netlify site is created; it is annotated as "use the exact subdomain Netlify shows in the dashboard."
+
+**3. Type consistency:** ADR 07 references the same build command (`pnpm install --frozen-lockfile && pnpm build`), publish dir (`dist`), env var names (`CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`), NODE_VERSION (`22`), and DNS targets (`apex-loadbalancer.netlify.com`, `<site-slug>.netlify.app`) as `netlify.toml` (Task 1), README/AGENTS.md (Task 3), and the operator runbook (Task 4). ADR 06's filename is referenced consistently as `docs/adrs/adr_06_cloudflare_pages.md` across ADR 07, README, and AGENTS.md.

--- a/docs/superpowers/specs/2026-07-23-netlify-primary-hosting-design.md
+++ b/docs/superpowers/specs/2026-07-23-netlify-primary-hosting-design.md
@@ -1,0 +1,232 @@
+# Netlify Primary Hosting Design
+
+- **Date:** 2026-07-23
+- **Status:** Approved
+- **Supersedes:** ADR 06 (`docs/adrs/adr_06_cloudflare_pages.md`) — production-traffic decision only; ADR 06 retained as historical record
+- **Related:** ADR 01 (Astro migration), ADR 05 (`adr_05_image_strategy.md`)
+
+## Summary
+
+Switch production traffic for `rhode-medizin.de` from Cloudflare Pages to
+Netlify, while keeping the Cloudflare Pages project configured and building as
+a dormant fallback. The Astro static build (`astro build` → `dist/`) is
+host-agnostic and requires no code or build changes; only hosting and DNS
+configuration change.
+
+## Motivation
+
+The Cloudflare Pages setup documented in ADR 06 requires moving DNS
+management fully to Cloudflare in order to provision an apex TLS certificate.
+Netlify permits the apex domain to remain at the existing registrar and
+provisions its certificate via DCV using an ALIAS/ANAME record at the apex and
+a CNAME for `www`. Keeping DNS at the registrar is preferable, so Netlify
+becomes the primary host.
+
+## Goals
+
+- Make Netlify the primary host for `rhode-medizin.de` and
+  `www.rhode-medizin.de` without transferring DNS to Netlify or Cloudflare.
+- Keep the existing Cloudflare Pages project configured and building on every
+  git push, so a DNS-only cutover can revert traffic to Cloudflare at any
+  time.
+- Trigger Netlify rebuilds automatically when Contentful content is published
+  or unpublished.
+- Introduce no changes to the Astro build, source code, or dependencies.
+
+## Non-goals
+
+- Renumbering existing ADR files (Approach A — append-only).
+- Custom HTTP headers, redirects, or Netlify Forms/Identity/Edge Functions.
+- Switching DNS provider to Netlify DNS.
+- Any change to `astro.config.mjs`, `package.json`, or `.astro`/`.ts` source.
+
+## Background
+
+### Current state
+
+- The Astro build produces a fully static `dist/` with no SSR adapter, no
+  service worker, and no runtime cookies (ADR 06). It is host-agnostic.
+- Cloudflare Pages is configured entirely in the dashboard; no
+  `wrangler.toml` or build config lives in the repo.
+- The Cloudflare build command is `pnpm install --frozen-lockfile && pnpm
+  build`; output dir `dist`; env vars `CONTENTFUL_SPACE_ID` and
+  `CONTENTFUL_DELIVERY_TOKEN` (AGENTS.md "Deploy").
+- `dist/404.html` is emitted by Astro; both Cloudflare Pages and Netlify
+  serve it automatically.
+- ADR 06 states "Netlify is decommissioned after production verification
+  passes." That decision is reversed by this design.
+
+### Legacy Netlify stack (Gatsby)
+
+The pre-Astro stack ran on Netlify and included a `requirements.txt` pinned to
+`fonttools`, `brotli`, and `zopfli`. That file existed only to support
+`subfont` for font subsetting; `subfont` is gone (ADR 04 handles fonts), so no
+`requirements.txt` is reintroduced. No Python runtime is needed for the Astro
+build on Netlify.
+
+## Design
+
+### 1. `netlify.toml` (committed to repo root)
+
+A new `netlify.toml` makes the Netlify build reproducible and self-documenting,
+mirroring the Cloudflare build command exactly:
+
+```toml
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"
+```
+
+- Same `pnpm` flow and same `dist` output as Cloudflare Pages.
+- `NODE_VERSION` pinned to current LTS supported by Astro and Netlify.
+- Secrets (`CONTENTFUL_SPACE_ID`, `CONTENTFUL_DELIVERY_TOKEN`) are set in the
+  Netlify dashboard, not committed — matching the Cloudflare convention.
+- No `[[redirects]]` or `[[headers]]` block. Astro emits `dist/404.html`,
+  which Netlify serves automatically. Platform defaults are acceptable.
+- `CONTENTFUL_PREVIEW_TOKEN` is not set for production builds, consistent with
+  ADR 06.
+
+### 2. DNS and TLS cutover
+
+DNS stays at the current registrar (the driver for this whole change).
+
+- Apex `rhode-medizin.de`: **ALIAS/ANAME** →
+  `apex-loadbalancer.netlify.com`.
+- `www.rhode-medizin.de`: **CNAME** → `<site-slug>.netlify.app` (per Netlify
+  dashboard).
+
+Netlify auto-provisions the TLS certificate via DCV (HTTP-01 over apex and
+`www`, with DNS-01 fallback for the apex). No DNS transfer to Netlify DNS or
+Cloudflare DNS is required.
+
+#### Netlify domain setup (operator runbook)
+
+1. Netlify → Site → Domain settings → Add custom domain
+   `rhode-medizin.de` and `www.rhode-medizin.de`.
+2. At the registrar: set the ALIAS (apex) and CNAME (`www`) per Netlify's
+   instructions.
+3. Wait for Netlify to issue and verify the certificate (dashboard shows
+   "Certificate verified"; typically minutes).
+4. Verify the site serves over `https://rhode-medizin.de` and
+   `https://www.rhode-medizin.de` with a valid cert.
+5. Verify `dist/404.html` is served for unknown paths.
+6. Optional future step: enable Netlify DNS only if DNS-provider migration
+   is ever desired — not required for this cutover.
+
+### 3. Cloudflare Pages fallback
+
+The Cloudflare Pages project is not deleted.
+
+- It keeps building on every git push with the same build command and the
+  same env vars.
+- The `*.pages.dev` URL remains functional for verification and as an
+  emergency fallback.
+- To switch traffic to Cloudflare in an emergency: repoint DNS (apex
+  ALIAS/ANAME and `www` CNAME) to the Cloudflare Pages target. Cloudflare
+  will provision the apex cert once DNS points at it; no DNS transfer is
+  required for the fallback itself. Netlify's cert remains valid; only DNS
+  changes.
+- This fallback path is documented but not load-tested as part of this
+  change; it is a dormant safety net, not an active mirror.
+
+### 4. Contentful → Netlify build webhook
+
+Content edits in Contentful must trigger a Netlify rebuild automatically
+(Netlify is primary; Cloudflare rebuilds stay on git push / manual).
+
+1. Netlify → Site → Build & deploy → Continuous deployment → Build hooks →
+   create a hook (e.g., `contentful-content-published`).
+2. Contentful → Settings → Webhooks → create webhook:
+   - URL: the Netlify build hook URL.
+   - Triggers: `publish` and `unpublish` on Entry and Asset.
+   - Filters: target this space only.
+3. Verify a Contentful publish/unpublish triggers a Netlify build via the
+   Netlify deploy log.
+
+### 5. ADR updates
+
+- **New: `docs/adrs/adr_07_netlify.md`** — Supersedes ADR 06 for production
+  traffic. Captures motivation (Cloudflare requires DNS transfer for apex
+  TLS; Netlify allows ALIAS/ANAME at the existing registrar), decision
+  (Netlify primary, Cloudflare Pages configured as dormant fallback), build
+  config, env vars, NODE_VERSION, DNS records, and the Contentful → Netlify
+  webhook. References `netlify.toml` and the operator runbook.
+- **Update: `docs/adrs/adr_06_cloudflare_pages.md`** — Status changed to
+  `Superseded by adr_07_netlify.md`. Add a one-line note in Context pointing
+  to ADR 07 for the reason. Body left intact as historical record.
+
+### 6. Docs updates
+
+- **`README.md` → Deploy section:** replace the Cloudflare-primary
+  instructions with Netlify-primary. Include the `netlify.toml` reference,
+  env-var names, DNS records (apex ALIAS/ANAME + `www` CNAME), Contentful
+  webhook setup, and a short "Cloudflare Pages fallback" subsection
+  referencing `docs/adrs/adr_06_cloudflare_pages.md` and
+  `docs/adrs/adr_07_netlify.md`.
+- **`AGENTS.md` → Deploy section:** update to reflect Netlify primary +
+  Cloudflare Pages fallback. Note that the build command
+  (`pnpm install --frozen-lockfile && pnpm build`) and env-var names are the
+  same on both platforms. Reference `netlify.toml` as the source of truth for
+  Netlify.
+
+### 7. ADR numbering
+
+Approach A (append-only) is used. Existing `adr_05_*` and `adr_06_*` filename
+collisions are left in place; historical plan/spec references to those
+filenames remain valid. The new ADR is `adr_07_netlify.md`. No README note is
+added about the historical collision.
+
+## Rollout
+
+1. Add `netlify.toml` to repo root.
+2. Configure Netlify site: connect repo, confirm build command picks up
+   `netlify.toml`, set env vars `CONTENTFUL_SPACE_ID` and
+   `CONTENTFUL_DELIVERY_TOKEN` in the Netlify dashboard.
+3. Trigger a Netlify build and verify `dist/` output (same parity checks
+   apply: `pnpm compare:pages` works against any host's served HTML).
+4. Add custom domains in Netlify, set DNS at registrar, wait for cert.
+5. Verify production URLs over HTTPS.
+6. Create Netlify build hook; configure Contentful webhook; verify a publish
+   triggers a build.
+7. Update ADR 06 status to Superseded; add `docs/adrs/adr_07_netlify.md`.
+8. Update `README.md` and `AGENTS.md` Deploy sections.
+9. Commit and push; confirm Netlify build succeeds on git push (Cloudflare
+   build also succeeds as fallback).
+
+## Verification
+
+- `netlify.toml` present at repo root and parsed by Netlify (visible in
+  deploy log).
+- `pnpm install --frozen-lockfile && pnpm build` succeeds locally and on
+  Netlify.
+- `dist/404.html` served by Netlify for an unknown path.
+- `https://rhode-medizin.de` and `https://www.rhode-medizin.de` serve the
+  Astro build with a valid TLS cert issued by Netlify.
+- A Contentful publish triggers a Netlify build (deploy log shows
+  "Triggered by webhook").
+- Cloudflare Pages build still succeeds on git push; `*.pages.dev` URL still
+  serves the site.
+- `docs/adrs/adr_07_netlify.md` exists; `docs/adrs/adr_06_cloudflare_pages.md`
+  status reads `Superseded by adr_07_netlify.md`.
+- `README.md` and `AGENTS.md` Deploy sections describe Netlify primary with
+  Cloudflare fallback.
+
+## Risks
+
+- **DNS propagation delay** at cutover: low risk because ALIAS/ANAME and
+  CNAME changes propagate within TTL; the previous records can be restored
+  if needed.
+- **Netlify build differs from Cloudflare build** in image optimization
+  output: the Astro image service runs at build time and is host-agnostic;
+  no runtime difference is expected. If parity is in doubt, run
+  `pnpm compare:pages` against the Netlify URL.
+- **Webhook delivery failure** goes unnoticed: Netlify shows webhook
+  delivery history in the dashboard; no alerting is configured as part of
+  this change.
+- **Cloudflare fallback drift**: Cloudflare builds continue on git push but
+  are not actively verified against the real domain. Risk is acceptable for
+  a dormant safety net; if Cloudflare is ever needed, run a fresh build and
+  parity check before repointing DNS.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"


### PR DESCRIPTION
Switches production traffic for `rhode-medizin.de` from Cloudflare Pages to Netlify so DNS can stay at the current registrar. Cloudflare requires moving DNS to Cloudflare for apex TLS; Netlify provisions TLS via DCV using an ALIAS/ANAME at the apex and a CNAME for `www`, with no DNS transfer. The Cloudflare Pages project stays configured and building on every git push as a dormant fallback.

The Astro static build (`astro build` → `dist/`) is host-agnostic — no code or build changes, only hosting/DNS config.

## What's in this PR

- `netlify.toml` — build config mirroring the Cloudflare build command, `NODE_VERSION=22`. No `requirements.txt` (the legacy file was for `subfont`, which is gone).
- `docs/adrs/adr_07_netlify.md` — new ADR capturing the motivation (DNS), decision (Netlify primary + Cloudflare fallback), build config, DNS records, and Contentful webhook.
- `docs/adrs/adr_06_cloudflare_pages.md` — status marked `Superseded by adr_07_netlify.md`; body left intact as historical record.
- `README.md` and `AGENTS.md` — Deploy sections rewritten: Netlify primary with `netlify.toml` reference, DNS records, Contentful webhook, and a Cloudflare Pages fallback subsection.
- Spec and implementation plan committed under `docs/superpowers/`.

## Out of scope (manual operator runbook)

The Netlify dashboard setup (site, env vars, custom domains), DNS records at the registrar, TLS verification, and the Contentful → Netlify build webhook are dashboard/manual steps tracked in the plan's Task 4 — they produce no repo changes and are not in this PR.

## Verification

- `pnpm lint` passes (Prettier check).
- `pnpm build` passes (`astro check` + `astro build` → `dist/`).
- Per-task subagent reviews: all Approved, no Critical/Important findings.
- Final whole-branch review: Ready to merge (1 Minor spec-vs-plan deviation fixed by controller).

Design: `docs/superpowers/specs/2026-07-23-netlify-primary-hosting-design.md`
Plan: `docs/superpowers/plans/2026-07-23-netlify-primary-hosting.md`